### PR TITLE
feat: perfil de usuario y modo oscuro consistente

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -21,6 +21,7 @@ import ValidacionRUNTPage from '@/pages/ValidacionRUNTPage.jsx';
 import HistorialValidacionesPage from '@/pages/HistorialValidacionesPage.jsx';
 import ReportesPage from '@/pages/ReportesPage.jsx';
 import ConfiguracionPage from '@/pages/ConfiguracionPage.jsx';
+import UserProfilePage from '@/pages/UserProfilePage.jsx';
 
 // App arma el árbol principal de providers y define qué vistas son públicas
 // y cuáles deben pasar por la protección de autenticación.
@@ -48,6 +49,7 @@ function App() {
                 <Route path="/validacion-runt" element={<ValidacionRUNTPage />} />
                 <Route path="/historial-validaciones" element={<HistorialValidacionesPage />} />
                 <Route path="/reportes" element={<ReportesPage />} />
+                <Route path="/perfil" element={<UserProfilePage />} />
                 <Route path="/configuracion" element={<ConfiguracionPage />} />
               </Route>
             </Route>

--- a/apps/web/src/components/Header.jsx
+++ b/apps/web/src/components/Header.jsx
@@ -1,33 +1,35 @@
 import React from 'react';
 import { useAuth } from '@/contexts/AuthContext.jsx';
 import { useOnboarding } from '@/contexts/OnboardingContext.jsx';
-import { LogOut, Menu, Bell, User, Sparkles } from 'lucide-react';
+import { Menu, Bell, Sparkles } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAlerts } from '@/hooks/useAlerts.js';
+import UserProfileDropdown from '@/components/UserProfileDropdown.jsx';
+import ThemeToggle from '@/components/ThemeToggle.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 
 // Header muestra el contexto actual del dashboard y concentra acciones globales:
 // navegación móvil, alertas activas y cierre de sesión.
 export default function Header({ toggleSidebar }) {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const { startTour } = useOnboarding();
   const location = useLocation();
   const navigate = useNavigate();
   const { alerts } = useAlerts();
+  const { isDarkMode } = useTheme();
 
   const alertCount = alerts.length;
   const hasActiveAlerts = alertCount > 0;
   const handleAlertsClick = () => navigate('/alertas');
-  const handleLogout = () => {
-    logout();
-    navigate('/');
-  };
 
   // El breadcrumb simple se deriva de la ruta activa para evitar títulos hardcodeados por vista.
   const pathNames = location.pathname.split('/').filter(x => x);
   const currentPage = pathNames.length > 0 ? pathNames[pathNames.length - 1] : 'Dashboard';
 
   return (
-    <header className="bg-syntix-navy text-white h-16 flex items-center justify-between px-4 lg:px-8 sticky top-0 z-30 shadow-md">
+    <header className={`h-16 sticky top-0 z-30 flex items-center justify-between px-4 text-white shadow-md lg:px-8 ${
+      isDarkMode ? 'bg-slate-900 border-b border-slate-800' : 'bg-syntix-navy'
+    }`}>
       <div className="flex items-center gap-4">
         <button onClick={toggleSidebar} className="lg:hidden p-2 text-gray-300 hover:bg-white/10 rounded-md">
           <Menu className="w-5 h-5" />
@@ -43,34 +45,38 @@ export default function Header({ toggleSidebar }) {
         <button
           type="button"
           onClick={startTour}
-          className="hidden md:inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-2 text-xs font-semibold text-gray-200 transition-colors hover:bg-white/10"
+          className={`hidden md:inline-flex items-center gap-2 rounded-full border px-3 py-2 text-xs font-semibold transition-colors ${
+            isDarkMode
+              ? 'border-slate-700 text-slate-200 hover:bg-slate-800'
+              : 'border-white/15 text-gray-200 hover:bg-white/10'
+          }`}
           title="Abrir tutorial"
         >
           <Sparkles className="w-4 h-4" />
           Tutorial
         </button>
+        <div className="hidden lg:block">
+          <ThemeToggle compact label="Tema" />
+        </div>
         <button
           onClick={handleAlertsClick}
-          className="p-2 text-gray-300 hover:bg-white/10 rounded-full relative"
+          className={`relative rounded-full p-2 ${
+            isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-gray-300 hover:bg-white/10'
+          }`}
           title="Ver alertas"
         >
           <Bell className="w-5 h-5" />
           {hasActiveAlerts && (
-            <span className="absolute top-1 right-1 w-2.5 h-2.5 bg-syntix-red rounded-full border-2 border-syntix-navy"></span>
+            <span className={`absolute top-1 right-1 h-2.5 w-2.5 rounded-full border-2 bg-syntix-red ${
+              isDarkMode ? 'border-slate-900' : 'border-syntix-navy'
+            }`}></span>
           )}
         </button>
-        <div className="flex items-center gap-3 border-l pl-4 border-white/20">
-          <div className="hidden md:block text-right">
-            <p className="text-sm font-medium text-white">{user?.empresa || 'Empresa'}</p>
-            <p className="text-xs text-gray-400">{user?.email}</p>
+        {user && (
+          <div className={`border-l pl-4 ${isDarkMode ? 'border-slate-700' : 'border-white/20'}`}>
+            <UserProfileDropdown variant="dark" />
           </div>
-          <div className="w-8 h-8 bg-syntix-green text-white rounded-full flex items-center justify-center font-bold text-sm">
-            <User className="w-4 h-4" />
-          </div>
-          <button onClick={handleLogout} className="p-2 text-gray-400 hover:text-syntix-red hover:bg-white/5 rounded-md transition-colors" title="Cerrar Sesión">
-            <LogOut className="w-5 h-5" />
-          </button>
-        </div>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/components/Header.jsx
+++ b/apps/web/src/components/Header.jsx
@@ -5,7 +5,6 @@ import { Menu, Bell, Sparkles } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAlerts } from '@/hooks/useAlerts.js';
 import UserProfileDropdown from '@/components/UserProfileDropdown.jsx';
-import ThemeToggle from '@/components/ThemeToggle.jsx';
 import { useTheme } from '@/contexts/ThemeContext.jsx';
 
 // Header muestra el contexto actual del dashboard y concentra acciones globales:
@@ -55,9 +54,6 @@ export default function Header({ toggleSidebar }) {
           <Sparkles className="w-4 h-4" />
           Tutorial
         </button>
-        <div className="hidden lg:block">
-          <ThemeToggle compact label="Tema" />
-        </div>
         <button
           onClick={handleAlertsClick}
           className={`relative rounded-full p-2 ${

--- a/apps/web/src/components/PublicHeader.jsx
+++ b/apps/web/src/components/PublicHeader.jsx
@@ -29,7 +29,7 @@ export default function PublicHeader({ onLoginClick, onRegisterClick }) {
 
           <div className="hidden md:flex items-center space-x-4">
             {isAuthenticated ? (
-              <UserProfileDropdown />
+              <UserProfileDropdown variant="light" />
             ) : (
               <>
                 <button onClick={onLoginClick} className="text-syntix-navy font-medium hover:text-syntix-green transition-colors">
@@ -61,7 +61,7 @@ export default function PublicHeader({ onLoginClick, onRegisterClick }) {
           <div className="pt-4 flex flex-col gap-3 border-t border-gray-100">
             {isAuthenticated ? (
               <div className="flex justify-center py-2">
-                <UserProfileDropdown />
+                <UserProfileDropdown variant="light" />
               </div>
             ) : (
               <>

--- a/apps/web/src/components/Sidebar.jsx
+++ b/apps/web/src/components/Sidebar.jsx
@@ -1,39 +1,44 @@
 import React from 'react';
 import { NavLink, Link } from 'react-router-dom';
-import { LayoutDashboard, Car, Users, FileText, BellRing, Search, BarChart3, Settings, X } from 'lucide-react';
+import { LayoutDashboard, Car, Users, FileText, BellRing, Search, BarChart3, Settings, User, X } from 'lucide-react';
 import { useAlerts } from '@/hooks/useAlerts.js';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 
 // Sidebar concentra los módulos del backoffice y refleja cuántas alertas siguen activas.
 export default function Sidebar({ isOpen, toggleSidebar }) {
-  const { totalAlerts } = useAlerts();
+  const { totalAlerts } = useAlerts();
+  const { isDarkMode } = useTheme();
 
-  const navItems = [
-    { path: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
-    { path: '/vehiculos', icon: Car, label: 'Vehículos' },
-    { path: '/conductores', icon: Users, label: 'Conductores' },
-    { path: '/documentos', icon: FileText, label: 'Documentos' },
-    { path: '/alertas', icon: BellRing, label: 'Alertas', badge: totalAlerts },
-    { path: '/validacion-runt', icon: Search, label: 'Validación RUNT' },
-    { path: '/reportes', icon: BarChart3, label: 'Reportes' },
-    { path: '/configuracion', icon: Settings, label: 'Configuración' },
-  ];
+  const navItems = [
+    { path: '/perfil', icon: User, label: 'Perfil' },
+    { path: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
+    { path: '/vehiculos', icon: Car, label: 'Vehículos' },
+    { path: '/conductores', icon: Users, label: 'Conductores' },
+    { path: '/documentos', icon: FileText, label: 'Documentos' },
+    { path: '/alertas', icon: BellRing, label: 'Alertas', badge: totalAlerts },
+    { path: '/validacion-runt', icon: Search, label: 'Validación RUNT' },
+    { path: '/reportes', icon: BarChart3, label: 'Reportes' },
+    { path: '/configuracion', icon: Settings, label: 'Configuración' },
+  ];
 
-  return (
-    <>
-      {isOpen && (
-        <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
-          onClick={toggleSidebar}
-        />
-      )}
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          onClick={toggleSidebar}
+        />
+      )}
 
-       <aside
+      <aside
           data-onboarding="sidebar"
-        className={`fixed lg:static inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 ease-in-out ${
-          isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
-        } flex flex-col`}
-      >
-        <div className="h-16 flex items-center justify-between px-6 border-b border-gray-100 bg-syntix-navy text-white">
+        className={`fixed inset-y-0 left-0 z-50 flex w-64 transform flex-col border-r transition-transform duration-200 ease-in-out lg:static ${
+          isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+        } ${isDarkMode ? 'border-slate-800 bg-slate-900 text-slate-100' : 'border-gray-200 bg-white'}`}
+      >
+        <div className={`flex h-16 items-center justify-between border-b px-6 text-white ${
+            isDarkMode ? 'border-slate-800 bg-slate-950' : 'border-gray-100 bg-syntix-navy'
+          }`}>
           <Link to="/" className="font-bold text-xl tracking-wider hover:opacity-80 transition-opacity cursor-pointer">
             SYNTIX <span className="text-syntix-green">TECH</span>
           </Link>
@@ -45,7 +50,7 @@ export default function Sidebar({ isOpen, toggleSidebar }) {
           </button>
         </div>
 
-        <nav className="flex-1 py-6 px-3 space-y-1 overflow-y-auto bg-gray-50">
+        <nav className={`flex-1 space-y-1 overflow-y-auto px-3 py-6 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
           {navItems.map((item) => (
             <NavLink
               key={item.path}
@@ -53,8 +58,10 @@ export default function Sidebar({ isOpen, toggleSidebar }) {
               className={({ isActive }) =>
                 `flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
                   isActive
-                    ? 'bg-syntix-green/10 text-syntix-green font-semibold'
-                    : 'text-gray-600 hover:bg-gray-100 hover:text-syntix-navy'
+                    ? 'bg-syntix-green/15 text-syntix-green font-semibold'
+                    : isDarkMode
+                      ? 'text-slate-300 hover:bg-slate-800 hover:text-white'
+                      : 'text-gray-600 hover:bg-gray-100 hover:text-syntix-navy'
                 }`
               }
             >
@@ -72,8 +79,8 @@ export default function Sidebar({ isOpen, toggleSidebar }) {
           ))}
         </nav>
 
-        <div className="p-4 border-t border-gray-200 bg-white">
-          <div className="text-xs text-gray-500 text-center font-medium">
+        <div className={`border-t p-4 ${isDarkMode ? 'border-slate-800 bg-slate-950' : 'border-gray-200 bg-white'}`}>
+          <div className={`text-center text-xs font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
             Drive Control v1.0
           </div>
         </div>

--- a/apps/web/src/components/ThemeToggle.jsx
+++ b/apps/web/src/components/ThemeToggle.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
+
+// ThemeToggle muestra un switch compacto reutilizable para activar/desactivar
+// el modo oscuro sin propagar lógica de tema por toda la UI.
+export default function ThemeToggle({ label = 'Modo oscuro', compact = false }) {
+  const { isDarkMode, toggleDarkMode } = useTheme();
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isDarkMode}
+      onClick={toggleDarkMode}
+      className={`flex items-center gap-3 rounded-2xl border px-4 py-3 transition-colors ${
+        compact
+          ? 'border-white/15 bg-white/10 text-white hover:bg-white/15'
+          : 'border-gray-200 bg-white text-gray-900 hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800'
+      }`}
+    >
+      <div className={`rounded-full p-2 ${compact ? 'bg-white/10' : 'bg-amber-50 dark:bg-slate-800'}`}>
+        {isDarkMode ? (
+          <Moon className={`h-4 w-4 ${compact ? 'text-syntix-green' : 'text-syntix-green'}`} />
+        ) : (
+          <Sun className={`h-4 w-4 ${compact ? 'text-amber-300' : 'text-amber-500'}`} />
+        )}
+      </div>
+
+      <div className="text-left">
+        <p className="text-sm font-semibold">{label}</p>
+        {!compact && (
+          <p className="text-xs text-gray-500 dark:text-slate-400">
+            {isDarkMode ? 'Activo' : 'Desactivado'}
+          </p>
+        )}
+      </div>
+
+      <span
+        className={`relative ml-auto inline-flex h-7 w-12 items-center rounded-full transition-colors ${
+          isDarkMode ? 'bg-syntix-green' : compact ? 'bg-white/25' : 'bg-gray-300 dark:bg-slate-700'
+        }`}
+      >
+        <span
+          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+            isDarkMode ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/UserProfileDropdown.jsx
+++ b/apps/web/src/components/UserProfileDropdown.jsx
@@ -2,13 +2,15 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext.jsx';
 import { Link, useNavigate } from 'react-router-dom';
 import { LayoutDashboard, Settings, LogOut, User } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 
 // Dropdown del perfil pensado para no saturar la cabecera con acciones secundarias del usuario.
-export default function UserProfileDropdown() {
+export default function UserProfileDropdown({ variant = 'light' }) {
   const { user, logout } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
   const navigate = useNavigate();
+  const { isDarkMode } = useTheme();
 
   useEffect(() => {
     // Se cierra al hacer clic fuera para que el menú no quede abierto por accidente.
@@ -30,50 +32,73 @@ export default function UserProfileDropdown() {
   if (!user) return null;
 
   const initial = user.empresa ? user.empresa.charAt(0).toUpperCase() : 'U';
+  const isDark = variant === 'dark';
+  const triggerClassName = isDark
+    ? 'flex items-center gap-3 rounded-full p-1.5 transition-colors focus:outline-none hover:bg-white/10'
+    : 'flex items-center gap-3 rounded-full p-1.5 transition-colors focus:outline-none hover:bg-gray-100';
+  const companyClassName = isDark ? 'text-sm font-bold text-white' : 'text-sm font-bold text-syntix-navy';
+  const emailClassName = isDark ? 'text-xs text-gray-300' : 'text-xs text-gray-500';
+  const useDarkMenu = isDark && isDarkMode;
+  const menuClassName = useDarkMenu
+    ? 'absolute right-0 z-50 mt-2 w-56 rounded-xl border border-slate-800 bg-slate-900 py-2 shadow-lg animate-in fade-in slide-in-from-top-2 duration-200'
+    : 'absolute right-0 z-50 mt-2 w-56 rounded-xl border border-gray-100 bg-white py-2 shadow-lg animate-in fade-in slide-in-from-top-2 duration-200';
+  const itemClassName = useDarkMenu
+    ? 'flex items-center gap-3 px-4 py-2.5 text-sm text-slate-200 transition-colors hover:bg-slate-800 hover:text-white'
+    : 'flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-gray-50 hover:text-syntix-navy';
 
   return (
     <div className="relative" ref={dropdownRef}>
       <button 
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-3 p-1.5 rounded-full hover:bg-gray-100 transition-colors focus:outline-none"
+        className={triggerClassName}
       >
         <div className="hidden md:block text-right">
-          <p className="text-sm font-bold text-syntix-navy">{user.empresa}</p>
-          <p className="text-xs text-gray-500">{user.email}</p>
+          <p className={companyClassName}>{user.empresa}</p>
+          <p className={emailClassName}>{user.email}</p>
         </div>
-        <div className="w-10 h-10 bg-syntix-green text-white rounded-full flex items-center justify-center font-bold text-lg shadow-sm">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-syntix-green text-lg font-bold text-white shadow-sm">
           {initial}
         </div>
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-56 bg-white rounded-xl shadow-lg border border-gray-100 py-2 z-50 animate-in fade-in slide-in-from-top-2 duration-200">
-          <div className="px-4 py-3 border-b border-gray-100 md:hidden">
-            <p className="text-sm font-bold text-gray-900 truncate">{user.empresa}</p>
-            <p className="text-xs text-gray-500 truncate">{user.email}</p>
+        <div className={menuClassName}>
+          <div className={`border-b px-4 py-3 md:hidden ${useDarkMenu ? 'border-slate-800' : 'border-gray-100'}`}>
+            <p className={`truncate text-sm font-bold ${useDarkMenu ? 'text-slate-100' : 'text-gray-900'}`}>{user.empresa}</p>
+            <p className={`truncate text-xs ${useDarkMenu ? 'text-slate-400' : 'text-gray-500'}`}>{user.email}</p>
           </div>
+
+          <Link 
+            to="/perfil" 
+            onClick={() => setIsOpen(false)}
+            className={itemClassName}
+          >
+            <User className="w-4 h-4" /> Perfil
+          </Link>
           
           <Link 
             to="/dashboard" 
             onClick={() => setIsOpen(false)}
-            className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 hover:text-syntix-navy transition-colors"
+            className={itemClassName}
           >
             <LayoutDashboard className="w-4 h-4" /> Dashboard
           </Link>
           
           <Link 
-            to="/ajustes-usuario" 
+            to="/configuracion" 
             onClick={() => setIsOpen(false)}
-            className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 hover:text-syntix-navy transition-colors"
+            className={itemClassName}
           >
-            <Settings className="w-4 h-4" /> Ajustes de Cuenta
+            <Settings className="w-4 h-4" /> Configuracion
           </Link>
           
-          <div className="h-px bg-gray-100 my-1"></div>
+          <div className={`my-1 h-px ${useDarkMenu ? 'bg-slate-800' : 'bg-gray-100'}`}></div>
           
           <button 
             onClick={handleLogout}
-            className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-syntix-red hover:bg-red-50 transition-colors"
+            className={`flex w-full items-center gap-3 px-4 py-2.5 text-sm text-syntix-red transition-colors ${
+              useDarkMenu ? 'hover:bg-red-500/10' : 'hover:bg-red-50'
+            }`}
           >
             <LogOut className="w-4 h-4" /> Cerrar Sesión
           </button>

--- a/apps/web/src/components/ValidacionResultadoCard.jsx
+++ b/apps/web/src/components/ValidacionResultadoCard.jsx
@@ -8,7 +8,8 @@ export default function ValidacionResultadoCard({
   vehiculoSistema,
   conductorAsignado,
   onGuardar,
-  loading = false
+  loading = false,
+  isDarkMode = false
 }) {
   if (!datosRUNT?.encontrado) {
     return (
@@ -72,61 +73,61 @@ export default function ValidacionResultadoCard({
       )}
 
       {/* Información del Vehículo */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h3 className="font-bold text-lg text-syntix-navy mb-4">Información del Vehículo</h3>
+      <div className={`rounded-xl border p-6 ${isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-200 bg-white'}`}>
+        <h3 className={`mb-4 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Información del Vehículo</h3>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Placa</p>
-            <p className="text-lg font-black text-gray-900">{data.placa}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Placa</p>
+            <p className={`text-lg font-black ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.placa}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Marca</p>
-            <p className="text-lg font-bold text-gray-900">{data.marca}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Marca</p>
+            <p className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.marca}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Línea</p>
-            <p className="text-lg font-bold text-gray-900">{data.linea}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Línea</p>
+            <p className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.linea}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Modelo</p>
-            <p className="text-lg font-bold text-gray-900">{data.modelo}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Modelo</p>
+            <p className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.modelo}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Color</p>
-            <p className="text-lg font-bold text-gray-900">{data.color}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Color</p>
+            <p className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.color}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">VIN</p>
-            <p className="text-xs font-mono text-gray-900">{data.vin}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>VIN</p>
+            <p className={`text-xs font-mono ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.vin}</p>
           </div>
         </div>
       </div>
 
       {/* Validación SOAT */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
+      <div className={`rounded-xl border p-6 ${isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-200 bg-white'}`}>
         <div className="flex items-center justify-between mb-4">
-          <h3 className="font-bold text-lg text-syntix-navy">Validación SOAT</h3>
+          <h3 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Validación SOAT</h3>
           <StatusBadge status={soatState} />
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Número Póliza</p>
-            <p className="font-mono font-bold text-gray-900">{data.soat.numero}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Número Póliza</p>
+            <p className={`font-mono font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.soat.numero}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Aseguradora</p>
-            <p className="font-bold text-gray-900">{data.soat.aseguradora}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Aseguradora</p>
+            <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.soat.aseguradora}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Inicio Vigencia</p>
-            <p className="font-bold text-gray-900">{new Date(data.soat.fechaInicio).toLocaleDateString('es-CO')}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Inicio Vigencia</p>
+            <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{new Date(data.soat.fechaInicio).toLocaleDateString('es-CO')}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Vencimiento</p>
-            <p className="font-bold text-gray-900">{new Date(data.soat.fechaVencimiento).toLocaleDateString('es-CO')}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Vencimiento</p>
+            <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{new Date(data.soat.fechaVencimiento).toLocaleDateString('es-CO')}</p>
           </div>
           <div className="col-span-2">
-            <p className="text-xs font-bold text-gray-500 uppercase">Días Restantes</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Días Restantes</p>
             <p className={`text-2xl font-black ${
               soatState === 'verde' ? 'text-green-600' : 
               soatState === 'amarillo' ? 'text-amber-600' : 'text-syntix-red'
@@ -138,26 +139,26 @@ export default function ValidacionResultadoCard({
       </div>
 
       {/* Validación RTM */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
+      <div className={`rounded-xl border p-6 ${isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-200 bg-white'}`}>
         <div className="flex items-center justify-between mb-4">
-          <h3 className="font-bold text-lg text-syntix-navy">Validación RTM (Tecnomecánica)</h3>
+          <h3 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Validación RTM (Tecnomecánica)</h3>
           <StatusBadge status={rtmState} />
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Número RTM</p>
-            <p className="font-mono font-bold text-gray-900">{data.rtm.numero}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Número RTM</p>
+            <p className={`font-mono font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.rtm.numero}</p>
           </div>
           <div>
-            <p className="text-xs font-bold text-gray-500 uppercase">Responsable</p>
-            <p className="font-bold text-gray-900">{data.rtm.responsable}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Responsable</p>
+            <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{data.rtm.responsable}</p>
           </div>
           <div className="col-span-2">
-            <p className="text-xs font-bold text-gray-500 uppercase">Vencimiento</p>
-            <p className="font-bold text-gray-900">{new Date(data.rtm.fechaVencimiento).toLocaleDateString('es-CO')}</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Vencimiento</p>
+            <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{new Date(data.rtm.fechaVencimiento).toLocaleDateString('es-CO')}</p>
           </div>
           <div className="col-span-2">
-            <p className="text-xs font-bold text-gray-500 uppercase">Días Restantes</p>
+            <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Días Restantes</p>
             <p className={`text-2xl font-black ${
               rtmState === 'verde' ? 'text-green-600' : 
               rtmState === 'amarillo' ? 'text-amber-600' : 'text-syntix-red'
@@ -169,9 +170,9 @@ export default function ValidacionResultadoCard({
       </div>
 
       {/* Validación Licencia */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
+      <div className={`rounded-xl border p-6 ${isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-200 bg-white'}`}>
         <div className="flex items-center justify-between mb-4">
-          <h3 className="font-bold text-lg text-syntix-navy">Validación Licencia</h3>
+          <h3 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Validación Licencia</h3>
           {conductorAsignado ? (
             <StatusBadge status={licenciaState} />
           ) : (
@@ -181,20 +182,20 @@ export default function ValidacionResultadoCard({
         {conductorAsignado ? (
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <p className="text-xs font-bold text-gray-500 uppercase">Conductor</p>
-              <p className="font-bold text-gray-900">{conductorAsignado.nombre}</p>
+              <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Conductor</p>
+              <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{conductorAsignado.nombre}</p>
             </div>
             <div>
-              <p className="text-xs font-bold text-gray-500 uppercase">Documento</p>
-              <p className="font-bold text-gray-900">{conductorAsignado.documento}</p>
+              <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Documento</p>
+              <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{conductorAsignado.documento}</p>
             </div>
             <div>
-              <p className="text-xs font-bold text-gray-500 uppercase">Categoría</p>
-              <p className="font-bold text-gray-900">{conductorAsignado.categoria}</p>
+              <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Categoría</p>
+              <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{conductorAsignado.categoria}</p>
             </div>
             <div>
-              <p className="text-xs font-bold text-gray-500 uppercase">Vencimiento</p>
-              <p className="font-bold text-gray-900">{new Date(conductorAsignado.fechaVencimiento).toLocaleDateString('es-CO')}</p>
+              <p className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Vencimiento</p>
+              <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{new Date(conductorAsignado.fechaVencimiento).toLocaleDateString('es-CO')}</p>
             </div>
           </div>
         ) : (

--- a/apps/web/src/contexts/ThemeContext.jsx
+++ b/apps/web/src/contexts/ThemeContext.jsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage.js';
+
+const ThemeContext = createContext(null);
+
+// ThemeProvider persiste la preferencia visual del usuario y la refleja como
+// clase global para que Tailwind active variantes dark sin acoplar cada vista
+// a una implementación distinta del tema.
+export function ThemeProvider({ children }) {
+  const [isDarkMode, setIsDarkMode] = useLocalStorage('syntix_dark_mode', false);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', Boolean(isDarkMode));
+    document.documentElement.dataset.theme = isDarkMode ? 'dark' : 'light';
+  }, [isDarkMode]);
+
+  const value = useMemo(
+    () => ({
+      isDarkMode: Boolean(isDarkMode),
+      setIsDarkMode: (value) => setIsDarkMode(Boolean(value)),
+      toggleDarkMode: () => setIsDarkMode((current) => !current),
+    }),
+    [isDarkMode, setIsDarkMode]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme debe usarse dentro de ThemeProvider');
+  }
+
+  return context;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -25,9 +25,42 @@
     --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
   }
+
+  .dark {
+    --background: 222 34% 9%;
+    --foreground: 210 40% 96%;
+    --card: 221 33% 13%;
+    --card-foreground: 210 40% 96%;
+    --popover: 221 33% 13%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 146 39% 37%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 217 24% 18%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 217 24% 18%;
+    --muted-foreground: 215 20% 70%;
+    --accent: 217 24% 18%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 72% 54%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217 24% 22%;
+    --input: 217 24% 22%;
+    --ring: 146 39% 37%;
+  }
+
+  html {
+    @apply bg-white dark:bg-slate-950;
+  }
 }
 
 body {
 	font-family: 'DM Sans', sans-serif;
     background-color: #f9fafb;
+    color: #0f172a;
+    transition: background-color 200ms ease, color 200ms ease;
+}
+
+.dark body {
+  background-color: #020617;
+  color: #e2e8f0;
 }

--- a/apps/web/src/layouts/DashboardLayout.jsx
+++ b/apps/web/src/layouts/DashboardLayout.jsx
@@ -4,15 +4,17 @@ import { Outlet } from 'react-router-dom';
 import Header from '@/components/Header.jsx';
 import OnboardingTour from '@/components/OnboardingTour.jsx';
 import Sidebar from '@/components/Sidebar.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 
 // DashboardLayout mantiene la estructura compartida del backoffice:
 // navegación lateral, cabecera fija y espacio central para cada módulo.
 export default function DashboardLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { isInteractionLocked } = useOnboarding();
+  const { isDarkMode } = useTheme();
 
   return (
-    <div className="flex h-screen bg-gray-100 overflow-hidden font-sans">
+    <div className={`flex h-screen overflow-hidden font-sans ${isDarkMode ? 'bg-slate-950' : 'bg-gray-100'}`}>
       <div
         aria-hidden={isInteractionLocked}
         className={isInteractionLocked ? 'pointer-events-none select-none' : ''}
@@ -29,7 +31,7 @@ export default function DashboardLayout() {
       >
         <Header toggleSidebar={() => setSidebarOpen(!sidebarOpen)} />
 
-        <main className="flex-1 overflow-y-auto p-4 lg:p-8">
+        <main className={`flex-1 overflow-y-auto p-4 lg:p-8 ${isDarkMode ? 'bg-slate-950 text-slate-100' : ''}`}>
           <div className="max-w-7xl mx-auto">
             <Outlet />
           </div>

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from '@/App';
+import { ThemeProvider } from '@/contexts/ThemeContext.jsx';
 import './index.css';
 
 // Punto de arranque único de React: aquí se monta toda la SPA sobre el nodo root.
@@ -11,10 +12,14 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     {googleClientId ? (
       <GoogleOAuthProvider clientId={googleClientId}>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </GoogleOAuthProvider>
     ) : (
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     )}
   </React.StrictMode>
 )

--- a/apps/web/src/pages/AlertasPage.jsx
+++ b/apps/web/src/pages/AlertasPage.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { BellRing, Calendar, ChevronDown, ChevronRight } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import { useAlerts } from '@/hooks/useAlerts.js';
 import { useSimulatedDate } from '@/hooks/useSimulatedDate.js';
 import { getExpirationAlertText } from '@/utils/dateUtils.js';
@@ -32,6 +33,7 @@ const toggleMapValue = (setter, key) => {
 // Centro de alertas: deja ver el estado consolidado del sistema para una fecha dada.
 export default function AlertasPage() {
   const { alerts } = useAlerts();
+  const { isDarkMode } = useTheme();
   const { simulatedDate, setSimulatedDate, resetDate } = useSimulatedDate();
   const [openSections, setOpenSections] = useState({ vehiculos: true, conductores: true });
   const [openGroups, setOpenGroups] = useState({ SOAT: true, RTM: true, Licencias: true });
@@ -63,40 +65,49 @@ export default function AlertasPage() {
 
       <div data-onboarding="alerts-header" className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-syntix-navy">Centro de Alertas</h1>
-          <p className="text-gray-500 text-sm mt-1">Notificaciones automaticas basadas en la Regla de Oro</p>
+          <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Centro de Alertas</h1>
+          <p className={`mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Notificaciones automaticas basadas en la Regla de Oro</p>
         </div>
 
-        <div data-onboarding="alerts-date-filter" className="bg-white p-2 rounded-lg border border-gray-200 shadow-sm flex items-center gap-3">
-          <Calendar className="w-5 h-5 text-gray-400 ml-2" />
+        <div data-onboarding="alerts-date-filter" className={`flex items-center gap-3 rounded-lg border p-2 shadow-sm ${
+          isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-200 bg-white'
+        }`}>
+          <Calendar className={`ml-2 w-5 h-5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`} />
           <div className="flex flex-col">
-            <label className="text-xs font-bold text-gray-500 uppercase">Simular Fecha</label>
+            <label className={`text-xs font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Simular Fecha</label>
             <input
               type="date"
               value={simulatedDate}
               onChange={(e) => setSimulatedDate(e.target.value)}
-              className="text-sm font-medium text-syntix-navy outline-none bg-transparent"
+              className={`bg-transparent text-sm font-medium outline-none ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}
+              style={{ colorScheme: isDarkMode ? 'dark' : 'light' }}
             />
           </div>
           <button
             data-onboarding="alerts-reset-date"
             onClick={resetDate}
-            className="text-xs bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded font-medium transition-colors"
+            className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+              isDarkMode ? 'bg-slate-800 text-slate-200 hover:bg-slate-700' : 'bg-gray-100 hover:bg-gray-200'
+            }`}
           >
             Hoy
           </button>
         </div>
       </div>
 
-      <div data-onboarding="alerts-list" className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+      <div data-onboarding="alerts-list" className={`rounded-2xl border p-6 shadow-sm ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
         <div className="flex justify-between items-center mb-6">
-          <h2 className="text-lg font-bold text-gray-900 flex items-center gap-2">
+          <h2 className={`flex items-center gap-2 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
             <BellRing className="w-5 h-5 text-syntix-navy" /> Alertas Activas ({alertCount})
           </h2>
         </div>
 
         {alertCount === 0 && (
-          <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-xl border border-dashed border-gray-200 mb-6">
+          <div className={`mb-6 rounded-xl border border-dashed py-8 text-center ${
+            isDarkMode ? 'border-slate-700 bg-slate-950/60 text-slate-400' : 'border-gray-200 bg-gray-50 text-gray-500'
+          }`}>
             No hay alertas activas para la fecha seleccionada.
           </div>
         )}
@@ -112,6 +123,7 @@ export default function AlertasPage() {
               openGroups={openGroups}
               onGroupToggle={(groupKey) => toggleMapValue(setOpenGroups, groupKey)}
               getGroupAlerts={getGroupAlerts}
+              isDarkMode={isDarkMode}
             />
           ))}
         </div>
@@ -128,24 +140,29 @@ function AlertSection({
   openGroups,
   onGroupToggle,
   getGroupAlerts,
+  isDarkMode,
 }) {
   const Icon = isOpen ? ChevronDown : ChevronRight;
 
   return (
-    <section className="border border-gray-100 rounded-xl bg-gray-50/60 overflow-hidden">
+    <section className={`overflow-hidden rounded-xl border ${
+      isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-gray-100 bg-gray-50/60'
+    }`}>
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
-        className="w-full flex items-center justify-between gap-4 px-4 py-4 text-left hover:bg-gray-50 transition-colors"
+        className={`w-full flex items-center justify-between gap-4 px-4 py-4 text-left transition-colors ${
+          isDarkMode ? 'hover:bg-slate-800/80' : 'hover:bg-gray-50'
+        }`}
       >
         <span className="flex items-center gap-3 min-w-0">
-          <Icon className="w-5 h-5 text-syntix-navy shrink-0" />
+          <Icon className={`w-5 h-5 shrink-0 ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`} />
           <span>
-            <span className="block font-bold text-syntix-navy">
+            <span className={`block font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>
               {section.title} ({count})
             </span>
-            <span className="block text-sm text-gray-500 mt-1">{section.description}</span>
+            <span className={`mt-1 block text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{section.description}</span>
           </span>
         </span>
       </button>
@@ -162,6 +179,7 @@ function AlertSection({
                 alerts={groupAlerts}
                 isOpen={Boolean(openGroups[group.key])}
                 onToggle={() => onGroupToggle(group.key)}
+                isDarkMode={isDarkMode}
               />
             );
           })}
@@ -171,19 +189,23 @@ function AlertSection({
   );
 }
 
-function AlertGroup({ title, alerts, isOpen, onToggle }) {
+function AlertGroup({ title, alerts, isOpen, onToggle, isDarkMode }) {
   const Icon = isOpen ? ChevronDown : ChevronRight;
 
   return (
-    <div className="border border-gray-100 rounded-xl bg-white overflow-hidden">
+    <div className={`overflow-hidden rounded-xl border ${
+      isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+    }`}>
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
-        className="w-full flex items-center justify-between gap-3 p-4 text-left hover:bg-gray-50 transition-colors"
+        className={`w-full flex items-center justify-between gap-3 p-4 text-left transition-colors ${
+          isDarkMode ? 'hover:bg-slate-800' : 'hover:bg-gray-50'
+        }`}
       >
-        <span className="flex items-center gap-2 font-bold text-gray-900">
-          <Icon className="w-4 h-4 text-gray-500 shrink-0" />
+        <span className={`flex items-center gap-2 font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
+          <Icon className={`w-4 h-4 shrink-0 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`} />
           {title} ({alerts.length})
         </span>
       </button>
@@ -191,13 +213,15 @@ function AlertGroup({ title, alerts, isOpen, onToggle }) {
       {isOpen && (
         <div className="px-4 pb-4">
           {alerts.length === 0 ? (
-            <div className="text-sm text-gray-500 bg-gray-50 rounded-lg border border-dashed border-gray-200 p-4">
+            <div className={`rounded-lg border border-dashed p-4 text-sm ${
+              isDarkMode ? 'border-slate-700 bg-slate-950/60 text-slate-400' : 'border-gray-200 bg-gray-50 text-gray-500'
+            }`}>
               No hay alertas activas en este grupo.
             </div>
           ) : (
             <div className="space-y-3">
               {alerts.map((alert) => (
-                <AlertItem key={alert.id} alert={alert} />
+                <AlertItem key={alert.id} alert={alert} isDarkMode={isDarkMode} />
               ))}
             </div>
           )}
@@ -207,32 +231,42 @@ function AlertGroup({ title, alerts, isOpen, onToggle }) {
   );
 }
 
-function AlertItem({ alert }) {
+function AlertItem({ alert, isDarkMode }) {
   const isCritical = alert.prioridad === 'rojo';
   const expirationText = getExpirationAlertText(alert.diasRestantes, alert.fechaVencimiento);
 
   return (
     <div
       className={`p-4 rounded-xl border flex items-start gap-4 shadow-sm ${
-        isCritical ? 'bg-red-50 border-red-100' : 'bg-yellow-50 border-yellow-100'
+        isCritical
+          ? isDarkMode ? 'bg-red-950/35 border-red-900' : 'bg-red-50 border-red-100'
+          : isDarkMode ? 'bg-amber-950/30 border-amber-900' : 'bg-yellow-50 border-yellow-100'
       }`}
     >
-      <div className={`p-2 rounded-lg ${isCritical ? 'bg-red-100 text-syntix-red' : 'bg-yellow-100 text-yellow-600'}`}>
+      <div className={`p-2 rounded-lg ${
+        isCritical
+          ? isDarkMode ? 'bg-red-950/80 text-red-300' : 'bg-red-100 text-syntix-red'
+          : isDarkMode ? 'bg-amber-950/80 text-amber-300' : 'bg-yellow-100 text-yellow-600'
+      }`}>
         <BellRing className="w-5 h-5" />
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex justify-between items-start gap-3">
-          <h5 className={`font-bold ${isCritical ? 'text-red-900' : 'text-yellow-900'}`}>
+          <h5 className={`font-bold ${isCritical ? (isDarkMode ? 'text-red-200' : 'text-red-900') : (isDarkMode ? 'text-amber-200' : 'text-yellow-900')}`}>
             {alert.mensaje}
           </h5>
-          <span className={`text-xs font-bold px-2 py-1 rounded-md whitespace-nowrap ${isCritical ? 'bg-red-200 text-red-800' : 'bg-yellow-200 text-yellow-800'}`}>
+          <span className={`text-xs font-bold px-2 py-1 rounded-md whitespace-nowrap ${
+            isCritical
+              ? isDarkMode ? 'bg-red-900 text-red-200' : 'bg-red-200 text-red-800'
+              : isDarkMode ? 'bg-amber-900 text-amber-200' : 'bg-yellow-200 text-yellow-800'
+          }`}>
             {alert.prioridad === 'rojo' ? 'Critica' : 'Proxima'}
           </span>
         </div>
-        <p className={`text-sm mt-1 ${isCritical ? 'text-red-700' : 'text-yellow-700'}`}>
+        <p className={`text-sm mt-1 ${isCritical ? (isDarkMode ? 'text-red-300' : 'text-red-700') : (isDarkMode ? 'text-amber-300' : 'text-yellow-700')}`}>
           <span className="font-semibold">{alert.tipo}:</span> {alert.entidad}
         </p>
-        <p className={`text-xs mt-2 font-semibold ${isCritical ? 'text-red-800' : 'text-yellow-800'}`}>
+        <p className={`text-xs mt-2 font-semibold ${isCritical ? (isDarkMode ? 'text-red-200' : 'text-red-800') : (isDarkMode ? 'text-amber-200' : 'text-yellow-800')}`}>
           {expirationText.fullText}
         </p>
       </div>

--- a/apps/web/src/pages/ConductoresPage.jsx
+++ b/apps/web/src/pages/ConductoresPage.jsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { Search, Plus, User, Trash2 } from 'lucide-react';
 import StatusBadge from '@/components/StatusBadge.jsx';
 import AddConductorModal from '@/components/AddConductorModal.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import { useConductors } from '@/hooks/useConductors.js';
 import { useVehicles } from '@/hooks/useVehicles.js';
 import { getVehicleOptionLabel } from '@/utils/colombiaFormats.js';
@@ -43,6 +44,7 @@ const getAssignedVehicleLabel = (conductor, vehiculos) => {
 export default function ConductoresPage() {
   const { conductores, deleteConductor } = useConductors();
   const { vehiculos } = useVehicles();
+  const { isDarkMode } = useTheme();
   const [searchTerm, setSearchTerm] = useState('');
   const [isConductorModalOpen, setIsConductorModalOpen] = useState(false);
   const [conductorToEdit, setConductorToEdit] = useState(null);
@@ -82,7 +84,7 @@ export default function ConductoresPage() {
       </Helmet>
 
       <div data-onboarding="conductors-header" className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <h1 className="text-2xl font-bold text-syntix-navy">Gestion de Conductores</h1>
+        <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Gestion de Conductores</h1>
         <button
           type="button"
           onClick={openCreateModal}
@@ -93,23 +95,31 @@ export default function ConductoresPage() {
         </button>
       </div>
 
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="p-4 border-b border-gray-100 bg-gray-50/50">
+      <div className={`overflow-hidden rounded-2xl border shadow-sm ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
+        <div className={`border-b p-4 ${isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-gray-100 bg-gray-50/50'}`}>
           <div data-onboarding="conductors-search" className="relative w-full sm:w-96">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <Search className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`} />
             <input
               type="text"
               placeholder="Buscar por nombre o documento..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-syntix-green focus:border-syntix-green outline-none"
+              className={`w-full rounded-lg border py-2 pl-9 pr-4 text-sm outline-none focus:border-syntix-green focus:ring-2 focus:ring-syntix-green ${
+                isDarkMode
+                  ? 'border-slate-700 bg-slate-900 text-slate-100 placeholder:text-slate-500'
+                  : 'border-gray-300 bg-white text-gray-900'
+              }`}
             />
           </div>
         </div>
 
         <div data-onboarding="conductors-table" className="overflow-x-auto">
-          <table className="w-full text-left text-sm text-gray-600">
-            <thead className="bg-gray-50 text-gray-700 font-semibold border-b border-gray-200">
+          <table className={`w-full text-left text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+            <thead className={`border-b font-semibold ${
+              isDarkMode ? 'border-slate-800 bg-slate-950 text-slate-300' : 'border-gray-200 bg-gray-50 text-gray-700'
+            }`}>
               <tr>
                 <th className="px-6 py-4">Conductor</th>
                 <th className="px-6 py-4">Documento</th>
@@ -120,29 +130,31 @@ export default function ConductoresPage() {
                 <th className="px-6 py-4 text-right">Acciones</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className={isDarkMode ? 'divide-y divide-slate-800' : 'divide-y divide-gray-100'}>
               {filtered.map((c) => {
                 const assignedVehicleLabel = getAssignedVehicleLabel(c, vehiculos);
 
                 return (
-                  <tr key={c.id} className="hover:bg-gray-50 transition-colors">
+                  <tr key={c.id} className={`transition-colors ${isDarkMode ? 'hover:bg-slate-800/70' : 'hover:bg-gray-50'}`}>
                     <td className="px-6 py-4 flex items-center gap-3">
-                      <div className="w-10 h-10 bg-syntix-navy/5 rounded-full flex items-center justify-center text-syntix-navy">
+                      <div className={`flex h-10 w-10 items-center justify-center rounded-full ${
+                        isDarkMode ? 'bg-slate-800 text-slate-100' : 'bg-syntix-navy/5 text-syntix-navy'
+                      }`}>
                         <User className="w-5 h-5" />
                       </div>
-                      <span className="font-bold text-gray-900">{c.nombre}</span>
+                      <span className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{c.nombre}</span>
                     </td>
                     <td className="px-6 py-4 font-medium">{c.documento}</td>
                     <td className="px-6 py-4">{c.telefono}</td>
                     <td className="px-6 py-4">
                       <div className="flex flex-col gap-1 items-start">
-                        <span className="text-xs font-bold text-gray-500">Cat: {c.categoria}</span>
+                        <span className={`text-xs font-bold ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Cat: {c.categoria}</span>
                         <StatusBadge status={c.estado} />
                       </div>
                     </td>
                     <td className="px-6 py-4">
                       <span
-                        className="block max-w-[240px] truncate text-sm font-medium text-gray-700"
+                        className={`block max-w-[240px] truncate text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
                         title={assignedVehicleLabel}
                       >
                         {assignedVehicleLabel}
@@ -150,21 +162,29 @@ export default function ConductoresPage() {
                     </td>
                     <td className="px-6 py-4 text-center">
                       <button
-                        type="button"
-                        onClick={() => openEditModal(c)}
-                        className="inline-flex items-center justify-center px-3 py-1.5 text-xs font-semibold text-syntix-navy bg-syntix-navy/5 hover:bg-syntix-navy/10 rounded-lg transition-colors"
-                        aria-label={`Editar conductor ${c.nombre}`}
-                      >
+                      type="button"
+                      onClick={() => openEditModal(c)}
+                      className={`inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                        isDarkMode
+                          ? 'bg-syntix-green/10 text-syntix-green hover:bg-syntix-green/20'
+                          : 'bg-syntix-navy/5 text-syntix-navy hover:bg-syntix-navy/10'
+                      }`}
+                      aria-label={`Editar conductor ${c.nombre}`}
+                    >
                         Editar
                       </button>
                     </td>
                     <td className="px-6 py-4 text-right">
                       <button
-                        type="button"
-                        onClick={() => deleteConductor(c.id)}
-                        className="p-2 text-gray-400 hover:text-syntix-red hover:bg-red-50 rounded-lg transition-colors"
-                        aria-label={`Eliminar conductor ${c.nombre}`}
-                      >
+                      type="button"
+                      onClick={() => deleteConductor(c.id)}
+                      className={`rounded-lg p-2 transition-colors ${
+                        isDarkMode
+                          ? 'text-slate-500 hover:bg-red-500/10 hover:text-red-300'
+                          : 'text-gray-400 hover:bg-red-50 hover:text-syntix-red'
+                      }`}
+                      aria-label={`Eliminar conductor ${c.nombre}`}
+                    >
                         <Trash2 className="w-4 h-4" />
                       </button>
                     </td>

--- a/apps/web/src/pages/ConfiguracionPage.jsx
+++ b/apps/web/src/pages/ConfiguracionPage.jsx
@@ -2,6 +2,8 @@ import React, { useState, useRef } from 'react';
 import { Helmet } from 'react-helmet';
 import { Settings, Save, Database, AlertTriangle, Upload, Download, CheckCircle } from 'lucide-react';
 import { useLocalStorage } from '@/hooks/useLocalStorage.js';
+import ThemeToggle from '@/components/ThemeToggle.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 
 // Configuración concentra ajustes de simulación y operaciones de respaldo local del MVP.
 export default function ConfiguracionPage() {
@@ -9,6 +11,7 @@ export default function ConfiguracionPage() {
   const [message, setMessage] = useState({ type: '', text: '' });
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const fileInputRef = useRef(null);
+  const { isDarkMode } = useTheme();
 
   const showMessage = (type, text) => {
     setMessage({ type, text });
@@ -85,24 +88,37 @@ export default function ConfiguracionPage() {
       </Helmet>
 
       <div data-onboarding="settings-header">
-        <h1 className="text-2xl font-bold text-syntix-navy">Configuración del Sistema</h1>
-        <p className="text-gray-500 text-sm mt-1">Ajustes generales y gestión de datos</p>
+        <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Configuración del Sistema</h1>
+        <p className={`mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Ajustes generales y gestión de datos</p>
       </div>
 
       {message.text && (
-        <div className={`p-4 rounded-lg flex items-center gap-3 ${message.type === 'success' ? 'bg-green-50 text-green-800 border border-green-200' : 'bg-red-50 text-red-800 border border-red-200'}`}>
+        <div className={`flex items-center gap-3 rounded-lg border p-4 ${
+          message.type === 'success'
+            ? isDarkMode
+              ? 'border-emerald-900 bg-emerald-950/70 text-emerald-300'
+              : 'border-green-200 bg-green-50 text-green-800'
+            : isDarkMode
+              ? 'border-red-950 bg-red-950/70 text-red-300'
+              : 'border-red-200 bg-red-50 text-red-800'
+        }`}>
           {message.type === 'success' ? <CheckCircle className="w-5 h-5" /> : <AlertTriangle className="w-5 h-5" />}
           <p className="text-sm font-medium">{message.text}</p>
         </div>
       )}
 
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="p-6 border-b border-gray-100">
-          <h2 className="text-lg font-bold text-gray-900 flex items-center gap-2 mb-4">
+      <div className={`overflow-hidden rounded-2xl border shadow-sm ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
+        <div className={`p-6 border-b ${isDarkMode ? 'border-slate-800' : 'border-gray-100'}`}>
+          <h2 className={`mb-4 flex items-center gap-2 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
             <Settings className="w-5 h-5 text-syntix-navy" /> Parámetros de Alertas
           </h2>
+          <div className="mb-6">
+            <ThemeToggle label="Modo oscuro" />
+          </div>
           <div data-onboarding="settings-threshold" className="max-w-md">
-            <label className="block text-sm font-bold text-gray-700 mb-2">
+            <label className={`mb-2 block text-sm font-bold ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}>
               Umbral de Alerta Amarilla (Días)
             </label>
             <div className="flex gap-4">
@@ -110,7 +126,11 @@ export default function ConfiguracionPage() {
                 type="number" 
                 value={threshold}
                 onChange={(e) => setThreshold(Number(e.target.value))}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-syntix-green outline-none"
+                className={`w-full rounded-lg border px-4 py-2 outline-none focus:ring-2 focus:ring-syntix-green ${
+                  isDarkMode
+                    ? 'border-slate-700 bg-slate-950 text-slate-100'
+                    : 'border-gray-300 bg-white text-gray-900'
+                }`}
                 min="1"
                 max="60"
               />
@@ -118,18 +138,22 @@ export default function ConfiguracionPage() {
                 <Save className="w-4 h-4" /> Guardar
               </button>
             </div>
-            <p className="text-xs text-gray-500 mt-2">
+            <p className={`mt-2 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
               Los documentos se marcarán en amarillo cuando falten {threshold} días o menos para su vencimiento.
             </p>
           </div>
         </div>
 
-        <div data-onboarding="settings-data-management" className="p-6 bg-gray-50">
-          <h2 className="text-lg font-bold text-gray-900 flex items-center gap-2 mb-4">
+        <div data-onboarding="settings-data-management" className={`p-6 ${isDarkMode ? 'bg-slate-950/60' : 'bg-gray-50'}`}>
+          <h2 className={`mb-4 flex items-center gap-2 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
             <Database className="w-5 h-5 text-syntix-navy" /> Gestión de Datos
           </h2>
           <div className="flex flex-wrap gap-4">
-            <button data-onboarding="settings-export" onClick={handleExportBackup} className="bg-white border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-100 transition-colors shadow-sm flex items-center gap-2">
+            <button data-onboarding="settings-export" onClick={handleExportBackup} className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium shadow-sm transition-colors ${
+              isDarkMode
+                ? 'border-slate-700 bg-slate-900 text-slate-200 hover:bg-slate-800'
+                : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'
+            }`}>
               <Download className="w-4 h-4" /> Exportar Respaldo
             </button>
             
@@ -140,11 +164,19 @@ export default function ConfiguracionPage() {
               ref={fileInputRef}
               onChange={handleImportBackup}
             />
-            <button data-onboarding="settings-import" onClick={() => fileInputRef.current?.click()} className="bg-white border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-100 transition-colors shadow-sm flex items-center gap-2">
+            <button data-onboarding="settings-import" onClick={() => fileInputRef.current?.click()} className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium shadow-sm transition-colors ${
+              isDarkMode
+                ? 'border-slate-700 bg-slate-900 text-slate-200 hover:bg-slate-800'
+                : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100'
+            }`}>
               <Upload className="w-4 h-4" /> Importar Respaldo
             </button>
             
-            <button data-onboarding="settings-reset" onClick={() => setShowResetConfirm(true)} className="bg-red-50 border border-red-200 text-syntix-red px-4 py-2 rounded-lg text-sm font-bold hover:bg-red-100 transition-colors shadow-sm flex items-center gap-2 ml-auto">
+            <button data-onboarding="settings-reset" onClick={() => setShowResetConfirm(true)} className={`ml-auto flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-bold shadow-sm transition-colors ${
+              isDarkMode
+                ? 'border-red-950 bg-red-950/50 text-red-300 hover:bg-red-950/70'
+                : 'border-red-200 bg-red-50 text-syntix-red hover:bg-red-100'
+            }`}>
               <AlertTriangle className="w-4 h-4" /> Restablecer Datos
             </button>
           </div>
@@ -154,16 +186,20 @@ export default function ConfiguracionPage() {
       {/* Reset Confirmation Modal */}
       {showResetConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-          <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md overflow-hidden p-6">
-            <div className="flex items-center gap-3 text-syntix-red mb-4">
+          <div className={`w-full max-w-md overflow-hidden rounded-2xl p-6 shadow-2xl ${
+            isDarkMode ? 'bg-slate-900 text-slate-100' : 'bg-white'
+          }`}>
+            <div className="mb-4 flex items-center gap-3 text-syntix-red">
               <AlertTriangle className="w-8 h-8" />
               <h2 className="text-xl font-bold">¿Restablecer todos los datos?</h2>
             </div>
-            <p className="text-gray-600 mb-6">
+            <p className={`mb-6 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
               Esta acción eliminará permanentemente todos los vehículos, conductores, documentos y configuraciones. La aplicación se reiniciará y volverá a la página de inicio. Esta acción no se puede deshacer.
             </p>
             <div className="flex justify-end gap-3">
-              <button onClick={() => setShowResetConfirm(false)} className="px-4 py-2 text-gray-600 font-medium hover:bg-gray-100 rounded-lg transition-colors">
+              <button onClick={() => setShowResetConfirm(false)} className={`rounded-lg px-4 py-2 font-medium transition-colors ${
+                isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-gray-600 hover:bg-gray-100'
+              }`}>
                 Cancelar
               </button>
               <button onClick={handleResetData} className="bg-syntix-red text-white px-6 py-2 rounded-lg font-medium hover:bg-red-600 transition-colors">

--- a/apps/web/src/pages/ConfiguracionPage.jsx
+++ b/apps/web/src/pages/ConfiguracionPage.jsx
@@ -112,7 +112,7 @@ export default function ConfiguracionPage() {
       }`}>
         <div className={`p-6 border-b ${isDarkMode ? 'border-slate-800' : 'border-gray-100'}`}>
           <h2 className={`mb-4 flex items-center gap-2 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
-            <Settings className="w-5 h-5 text-syntix-navy" /> Parámetros de Alertas
+            <Settings className={`w-5 h-5 ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`} /> Parámetros de Alertas
           </h2>
           <div className="mb-6">
             <ThemeToggle label="Modo oscuro" />
@@ -146,7 +146,7 @@ export default function ConfiguracionPage() {
 
         <div data-onboarding="settings-data-management" className={`p-6 ${isDarkMode ? 'bg-slate-950/60' : 'bg-gray-50'}`}>
           <h2 className={`mb-4 flex items-center gap-2 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
-            <Database className="w-5 h-5 text-syntix-navy" /> Gestión de Datos
+            <Database className={`w-5 h-5 ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`} /> Gestión de Datos
           </h2>
           <div className="flex flex-wrap gap-4">
             <button data-onboarding="settings-export" onClick={handleExportBackup} className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium shadow-sm transition-colors ${

--- a/apps/web/src/pages/DashboardPage.jsx
+++ b/apps/web/src/pages/DashboardPage.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import ModalFactory from '@/components/ModalFactory.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import useModalManager from '@/hooks/useModalManager.js';
 import { useVehicles } from '@/hooks/useVehicles.js';
 import { useConductors } from '@/hooks/useConductors.js';
@@ -11,6 +12,7 @@ export default function DashboardPage() {
   const { vehiculos } = useVehicles();
   const { conductores } = useConductors();
   const { alerts } = useAlerts();
+  const { isDarkMode } = useTheme();
   const { activeModal, openModal, closeModal } = useModalManager();
 
   // Las tarjetas superiores sintetizan el estado del sistema sin obligar a entrar a cada módulo.
@@ -30,32 +32,35 @@ export default function DashboardPage() {
 
   const recentVehicles = useMemo(() => vehiculos.slice(-3).reverse(), [vehiculos]);
   const openVehicleModal = () => openModal('addVehicle');
+  const pageTextColor = isDarkMode ? '#e2e8f0' : '#111827';
+  const mutedTextColor = isDarkMode ? '#94a3b8' : '#555';
+  const secondaryTextColor = isDarkMode ? '#64748b' : '#888';
 
   return (
-    <div style={{ padding: 20, fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Arial' }}>
+    <div style={{ padding: 20, fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Arial', color: pageTextColor }}>
       <div
         data-onboarding="dashboard-summary"
         style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}
       >
         <div>
-          <h1 style={{ margin: 0, fontSize: 26 }}>Dashboard</h1>
-          <p style={{ marginTop: 6, color: '#555' }}>
+          <h1 style={{ margin: 0, fontSize: 26, color: pageTextColor }}>Dashboard</h1>
+          <p style={{ marginTop: 6, color: mutedTextColor }}>
             Resumen operativo de DriveControl con accesos rápidos para navegar y registrar vehículos.
           </p>
         </div>
 
         <div data-onboarding="dashboard-header-actions" style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          <Link to="/vehiculos" data-onboarding="dashboard-action-vehicles" style={btnSecondary}>
+          <Link to="/vehiculos" data-onboarding="dashboard-action-vehicles" style={btnSecondary(isDarkMode)}>
             Ir a Vehículos
           </Link>
-          <button type="button" onClick={openVehicleModal} data-onboarding="dashboard-action-add-vehicle" style={btnPrimary}>
+          <button type="button" onClick={openVehicleModal} data-onboarding="dashboard-action-add-vehicle" style={btnPrimary(isDarkMode)}>
             + Vehículo
           </button> 
           <button
               type="button"
               onClick={() => openModal('addDocument')}
               data-onboarding="dashboard-action-add-soat"
-              style={btnSecondary}
+              style={btnSecondary(isDarkMode)}
             >
               + SOAT
             </button>
@@ -63,7 +68,7 @@ export default function DashboardPage() {
               type="button"
               onClick={() => openModal('addRtm')}
               data-onboarding="dashboard-action-add-rtm"
-              style={btnSecondary}
+              style={btnSecondary(isDarkMode)}
             >
               + RTM
             </button>
@@ -75,81 +80,81 @@ export default function DashboardPage() {
           <div
             key={s.label}
             data-onboarding={`dashboard-stat-${s.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
-            style={card}
+            style={card(isDarkMode)}
           >
-            <div style={{ color: '#666', fontSize: 13 }}>{s.label}</div>
-            <div style={{ fontSize: 28, fontWeight: 700, marginTop: 6 }}>{s.value}</div>
-            <div style={{ color: '#888', fontSize: 12, marginTop: 4 }}>{s.hint}</div>
+            <div style={{ color: mutedTextColor, fontSize: 13 }}>{s.label}</div>
+            <div style={{ fontSize: 28, fontWeight: 700, marginTop: 6, color: pageTextColor }}>{s.value}</div>
+            <div style={{ color: secondaryTextColor, fontSize: 12, marginTop: 4 }}>{s.hint}</div>
           </div>
         ))}
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 12, marginTop: 14 }}>
-        <div data-onboarding="dashboard-quick-actions" style={card}>
-          <h2 style={h2}>Accesos rápidos</h2>
+        <div data-onboarding="dashboard-quick-actions" style={card(isDarkMode)}>
+          <h2 style={h2(isDarkMode)}>Accesos rápidos</h2>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 }}>
-            <Link to="/vehiculos" data-onboarding="dashboard-quick-vehicles" style={quickLink}>Vehículos</Link>
-            <Link to="/conductores" data-onboarding="dashboard-quick-conductores" style={quickLink}>Conductores</Link>
-            <Link to="/documentos" data-onboarding="dashboard-quick-documentos" style={quickLink}>Documentos</Link>
-            <Link to="/alertas" data-onboarding="dashboard-quick-alertas" style={quickLink}>Alertas</Link>
-            <Link to="/validacion-runt" data-onboarding="dashboard-quick-runt" style={quickLink}>Validación RUNT</Link>
-            <Link to="/reportes" data-onboarding="dashboard-quick-reportes" style={quickLink}>Reportes</Link>
+            <Link to="/vehiculos" data-onboarding="dashboard-quick-vehicles" style={quickLink(isDarkMode)}>Vehículos</Link>
+            <Link to="/conductores" data-onboarding="dashboard-quick-conductores" style={quickLink(isDarkMode)}>Conductores</Link>
+            <Link to="/documentos" data-onboarding="dashboard-quick-documentos" style={quickLink(isDarkMode)}>Documentos</Link>
+            <Link to="/alertas" data-onboarding="dashboard-quick-alertas" style={quickLink(isDarkMode)}>Alertas</Link>
+            <Link to="/validacion-runt" data-onboarding="dashboard-quick-runt" style={quickLink(isDarkMode)}>Validación RUNT</Link>
+            <Link to="/reportes" data-onboarding="dashboard-quick-reportes" style={quickLink(isDarkMode)}>Reportes</Link>
           </div>
         </div>
 
-        <div data-onboarding="dashboard-recent-vehicles" style={card}>
+        <div data-onboarding="dashboard-recent-vehicles" style={card(isDarkMode)}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
-            <h2 style={h2}>Vehículos recientes</h2>
-            <Link to="/vehiculos" style={smallLink}>Ver todos →</Link>
+            <h2 style={h2(isDarkMode)}>Vehículos recientes</h2>
+            <Link to="/vehiculos" style={smallLink(isDarkMode)}>Ver todos →</Link>
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 8 }}>
             {recentVehicles.length > 0 ? (
               recentVehicles.map((vehicle) => (
-                <div key={vehicle.id} style={alertRow}>
+                <div key={vehicle.id} style={alertRow(isDarkMode)}>
                   <span style={badge(vehicle.estadoGeneral === 'verde' ? 'Baja' : vehicle.estadoGeneral === 'amarillo' ? 'Media' : 'Alta')}>
                     {vehicle.placa}
                   </span>
                   <div>
-                    <div style={{ fontWeight: 600 }}>{vehicle.marca} {vehicle.modelo}</div>
-                    <div style={{ fontSize: 13, color: '#666', marginTop: 2 }}>
+                    <div style={{ fontWeight: 600, color: pageTextColor }}>{vehicle.marca} {vehicle.modelo}</div>
+                    <div style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }}>
                       {vehicle.tipo}
                     </div>
                   </div>
                 </div>
               ))
             ) : (
-              <p style={{ color: '#666', fontSize: 13, marginTop: 8 }}>
+              <p style={{ color: mutedTextColor, fontSize: 13, marginTop: 8 }}>
                 No hay vehículos registrados todavía.
               </p>
             )}
           </div>
         </div>
 
-        <div data-onboarding="dashboard-recent-alerts" style={card}>
+        <div data-onboarding="dashboard-recent-alerts" style={card(isDarkMode)}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
-            <h2 style={h2}>Alertas recientes</h2>
-            <Link to="/alertas" style={smallLink}>Ver todas →</Link>
+            <h2 style={h2(isDarkMode)}>Alertas recientes</h2>
+            <Link to="/alertas" style={smallLink(isDarkMode)}>Ver todas →</Link>
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 8 }}>
             {alerts.slice(0, 3).map((a) => (
-              <div key={a.id} style={alertRow}>
+              <div key={a.id} style={alertRow(isDarkMode)}>
                 <span style={badge(a.prioridad === 'rojo' ? 'Alta' : a.prioridad === 'amarillo' ? 'Media' : 'Baja')}>
                   {a.tipo}
                 </span>
                 <div>
-                  <div style={{ fontWeight: 600 }}>{a.mensaje}</div>
-                  <div style={{ fontSize: 13, color: '#666', marginTop: 2 }}>{a.entidad}</div>
+                  <div style={{ fontWeight: 600, color: pageTextColor }}>{a.mensaje}</div>
+                  <div style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }}>{a.entidad}</div>
                 </div>
               </div>
             ))}
           </div>
         </div>
 
-        <div data-onboarding="dashboard-doc-status" style={card}>
-          <h2 style={h2}>Estado documental</h2>
-          <p style={{ marginTop: 6, color: '#666', fontSize: 13 }}>
+        <div data-onboarding="dashboard-doc-status" style={card(isDarkMode)}>
+          <h2 style={h2(isDarkMode)}>Estado documental</h2>
+          <p style={{ marginTop: 6, color: mutedTextColor, fontSize: 13 }}>
             Aquí puedes revisar el semáforo documental de los vehículos y entrar rápidamente al módulo correspondiente.
           </p>
 
@@ -160,8 +165,8 @@ export default function DashboardPage() {
           </div>
 
           <div data-onboarding="dashboard-doc-links" style={{ marginTop: 12, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-            <Link to="/documentos" style={btnSecondary}>Ir a Documentos</Link>
-            <Link to="/vehiculos" style={btnSecondary}>Ir a Vehículos</Link>
+            <Link to="/documentos" style={btnSecondary(isDarkMode)}>Ir a Documentos</Link>
+            <Link to="/vehiculos" style={btnSecondary(isDarkMode)}>Ir a Vehículos</Link>
           </div>
         </div>
       </div>
@@ -171,19 +176,19 @@ export default function DashboardPage() {
   );
 }
 
-const card = {
-  border: '1px solid #eee',
+const card = (isDarkMode) => ({
+  border: isDarkMode ? '1px solid #1e293b' : '1px solid #eee',
   borderRadius: 14,
   padding: 14,
-  background: '#fff',
-  boxShadow: '0 1px 8px rgba(0,0,0,0.04)',
-};
+  background: isDarkMode ? '#0f172a' : '#fff',
+  boxShadow: isDarkMode ? '0 1px 8px rgba(0,0,0,0.18)' : '0 1px 8px rgba(0,0,0,0.04)',
+});
 
-const h2 = { margin: 0, fontSize: 16 };
+const h2 = (isDarkMode) => ({ margin: 0, fontSize: 16, color: isDarkMode ? '#f8fafc' : '#111827' });
 
-const btnPrimary = {
+const btnPrimary = (isDarkMode) => ({
   textDecoration: 'none',
-  background: '#111',
+  background: isDarkMode ? '#1f2937' : '#111',
   color: '#fff',
   padding: '10px 12px',
   borderRadius: 10,
@@ -191,47 +196,48 @@ const btnPrimary = {
   fontSize: 13,
   border: 'none',
   cursor: 'pointer',
-};
+});
 
-const btnSecondary = {
+const btnSecondary = (isDarkMode) => ({
   textDecoration: 'none',
-  background: '#f3f4f6',
-  color: '#111',
+  background: isDarkMode ? '#111827' : '#f3f4f6',
+  color: isDarkMode ? '#e2e8f0' : '#111',
   padding: '10px 12px',
   borderRadius: 10,
   fontWeight: 600,
   fontSize: 13,
-};
+  border: isDarkMode ? '1px solid #334155' : 'none',
+});
 
-const quickLink = {
+const quickLink = (isDarkMode) => ({
   textDecoration: 'none',
-  border: '1px solid #eee',
+  border: isDarkMode ? '1px solid #334155' : '1px solid #eee',
   borderRadius: 12,
   padding: '12px 10px',
-  color: '#111',
+  color: isDarkMode ? '#e2e8f0' : '#111',
   fontWeight: 600,
   fontSize: 13,
-  background: '#fafafa',
+  background: isDarkMode ? '#020617' : '#fafafa',
   textAlign: 'center',
-};
+});
 
-const smallLink = {
+const smallLink = (isDarkMode) => ({
   textDecoration: 'none',
-  color: '#111',
+  color: isDarkMode ? '#f8fafc' : '#111',
   fontSize: 13,
   fontWeight: 600,
-};
+});
 
-const alertRow = {
+const alertRow = (isDarkMode) => ({
   display: 'grid',
   gridTemplateColumns: '64px 1fr',
   gap: 10,
   alignItems: 'start',
   padding: 10,
-  border: '1px solid #eee',
+  border: isDarkMode ? '1px solid #1e293b' : '1px solid #eee',
   borderRadius: 12,
-  background: '#fafafa',
-};
+  background: isDarkMode ? '#020617' : '#fafafa',
+});
 
 function badge(level) {
   const map = {

--- a/apps/web/src/pages/DocumentosPage.jsx
+++ b/apps/web/src/pages/DocumentosPage.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Search, Shield, Wrench, Pencil, Trash2 } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import { useDocuments } from '@/hooks/useDocuments.js';
 import { useRtm } from '@/contexts/RtmContext.jsx';
 import { useVehicles } from '@/hooks/useVehicles.js';
@@ -61,6 +62,7 @@ export default function DocumentosPage() {
   const { soats, removeSoat } = useDocuments();
   const { rtms, removeRtm } = useRtm();
   const { vehiculos } = useVehicles();
+  const { isDarkMode } = useTheme();
   const { activeModal, openModal, closeModal } = useModalManager();
 
   const [soatEditando, setSoatEditando] = useState(null);
@@ -130,17 +132,17 @@ export default function DocumentosPage() {
   };
 
   return (
-    <div className="p-8 bg-gray-50 min-h-screen">
+    <div className={`min-h-screen p-8 ${isDarkMode ? 'bg-slate-950' : 'bg-gray-50'}`}>
       <Helmet>
         <title>Documentos | SYNTIX Drive Control</title>
       </Helmet>
 
       <div data-onboarding="documents-header" className="mb-8 flex items-start justify-between gap-3 flex-wrap">
         <div>
-          <h1 className="text-4xl font-extrabold text-syntix-navy mb-2">
+          <h1 className={`mb-2 text-4xl font-extrabold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>
             Gestion de Documentos
           </h1>
-          <p className="text-gray-500 text-lg">Control de SOAT y Tecnomecanica</p>
+          <p className={`text-lg ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Control de SOAT y Tecnomecanica</p>
         </div>
         <div className="flex gap-2">
           <button
@@ -155,7 +157,11 @@ export default function DocumentosPage() {
             type="button"
             onClick={() => openModal('addRtm')}
             data-onboarding="documents-add-rtm"
-            className="bg-white text-gray-900 border border-gray-200 px-4 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50"
+            className={`rounded-lg border px-4 py-2 text-sm font-semibold ${
+              isDarkMode
+                ? 'border-slate-700 bg-slate-900 text-slate-100 hover:bg-slate-800'
+                : 'border-gray-200 bg-white text-gray-900 hover:bg-gray-50'
+            }`}
           >
             + RTM
           </button>
@@ -171,22 +177,23 @@ export default function DocumentosPage() {
         searchTerm={soatSearch}
         onSearchChange={setSoatSearch}
         placeholder="Buscar SOAT por placa, poliza, aseguradora, estado o vencimiento..."
+        isDarkMode={isDarkMode}
       >
         <table className="w-full min-w-[1100px]">
-          <thead className="bg-gray-50 text-left">
+          <thead className={`text-left ${isDarkMode ? 'bg-slate-950' : 'bg-gray-50'}`}>
             <tr>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Vehiculo</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">N° Poliza</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Aseguradora</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Inicio</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Fin vigencia</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Estado</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Acciones</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Vehiculo</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>N° Poliza</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Aseguradora</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Inicio</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Fin vigencia</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Estado</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Acciones</th>
             </tr>
           </thead>
           <tbody>
             {filteredSoats.length === 0 ? (
-              <EmptyRows colSpan={7} hasData={soats.length > 0} />
+              <EmptyRows colSpan={7} hasData={soats.length > 0} isDarkMode={isDarkMode} />
             ) : (
               filteredSoats.map((soat) => {
                 const vehiculo = getVehiculo(soat.vehiculoId);
@@ -194,17 +201,17 @@ export default function DocumentosPage() {
                 const expirationText = getExpirationAlertText(soat.diasRestantes, soat.fechaFinVigencia);
 
                 return (
-                  <tr key={soat.id} className="border-t border-gray-100 hover:bg-gray-50">
+                  <tr key={soat.id} className={`border-t ${isDarkMode ? 'border-slate-800 hover:bg-slate-800/70' : 'border-gray-100 hover:bg-gray-50'}`}>
                     <td className="px-6 py-4">
-                      <div className="font-bold text-gray-900">{placa}</div>
-                      <div className="text-xs text-gray-500">{getVehicleSubtitle(vehiculo)}</div>
+                      <div className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{placa}</div>
+                      <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{getVehicleSubtitle(vehiculo)}</div>
                     </td>
-                    <td className="px-6 py-4 text-gray-700">{soat.numeroPoliza}</td>
-                    <td className="px-6 py-4 text-gray-700">{soat.aseguradora || 'Sin dato'}</td>
-                    <td className="px-6 py-4 text-gray-700">{formatColombianDate(soat.fechaInicioVigencia)}</td>
-                    <td className="px-6 py-4 text-gray-700">
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>{soat.numeroPoliza}</td>
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>{soat.aseguradora || 'Sin dato'}</td>
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>{formatColombianDate(soat.fechaInicioVigencia)}</td>
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
                       <div>{formatColombianDate(soat.fechaFinVigencia)}</div>
-                      <div className="text-xs text-gray-500 mt-1">{expirationText.primaryText}</div>
+                      <div className={`mt-1 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{expirationText.primaryText}</div>
                     </td>
                     <td className="px-6 py-4">
                       <span className={`px-3 py-1 rounded-full text-sm font-semibold ${getBadgeClasses(soat.estado)}`}>
@@ -215,6 +222,7 @@ export default function DocumentosPage() {
                       <RowActions
                         onEdit={() => setSoatEditando(soat)}
                         onDelete={() => setConfirmDelete({ tipo: 'soat', id: soat.id, nombre: soat.numeroPoliza })}
+                        isDarkMode={isDarkMode}
                       />
                     </td>
                   </tr>
@@ -234,22 +242,23 @@ export default function DocumentosPage() {
         searchTerm={rtmSearch}
         onSearchChange={setRtmSearch}
         placeholder="Buscar RTM por placa, certificado, CDA, resultado, estado o vencimiento..."
+        isDarkMode={isDarkMode}
       >
         <table className="w-full min-w-[1100px]">
-          <thead className="bg-gray-50 text-left">
+          <thead className={`text-left ${isDarkMode ? 'bg-slate-950' : 'bg-gray-50'}`}>
             <tr>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Vehiculo</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Certificado</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">CDA</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Resultado</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Vencimiento</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Estado</th>
-              <th className="px-6 py-4 text-syntix-navy font-bold">Acciones</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Vehiculo</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Certificado</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>CDA</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Resultado</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Vencimiento</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Estado</th>
+              <th className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>Acciones</th>
             </tr>
           </thead>
           <tbody>
             {filteredRtms.length === 0 ? (
-              <EmptyRows colSpan={7} hasData={rtms.length > 0} />
+              <EmptyRows colSpan={7} hasData={rtms.length > 0} isDarkMode={isDarkMode} />
             ) : (
               filteredRtms.map((rtm) => {
                 const vehiculo = getVehiculo(rtm.vehiculoId);
@@ -257,17 +266,17 @@ export default function DocumentosPage() {
                 const expirationText = getExpirationAlertText(rtm.diasRestantes, rtm.fechaVencimiento);
 
                 return (
-                  <tr key={rtm.id} className="border-t border-gray-100 hover:bg-gray-50">
+                  <tr key={rtm.id} className={`border-t ${isDarkMode ? 'border-slate-800 hover:bg-slate-800/70' : 'border-gray-100 hover:bg-gray-50'}`}>
                     <td className="px-6 py-4">
-                      <div className="font-bold text-gray-900">{placa}</div>
-                      <div className="text-xs text-gray-500">{getVehicleSubtitle(vehiculo)}</div>
+                      <div className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{placa}</div>
+                      <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{getVehicleSubtitle(vehiculo)}</div>
                     </td>
-                    <td className="px-6 py-4 text-gray-700">{rtm.numeroCertificado}</td>
-                    <td className="px-6 py-4 text-gray-700">{rtm.cda || 'Sin dato'}</td>
-                    <td className="px-6 py-4 text-gray-700">{rtm.resultado || 'Sin dato'}</td>
-                    <td className="px-6 py-4 text-gray-700">
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>{rtm.numeroCertificado}</td>
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>{rtm.cda || 'Sin dato'}</td>
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>{rtm.resultado || 'Sin dato'}</td>
+                    <td className={`px-6 py-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
                       <div>{formatColombianDate(rtm.fechaVencimiento)}</div>
-                      <div className="text-xs text-gray-500 mt-1">{expirationText.primaryText}</div>
+                      <div className={`mt-1 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{expirationText.primaryText}</div>
                     </td>
                     <td className="px-6 py-4">
                       <span className={`px-3 py-1 rounded-full text-sm font-semibold ${getBadgeClasses(rtm.estado)}`}>
@@ -278,6 +287,7 @@ export default function DocumentosPage() {
                       <RowActions
                         onEdit={() => setRtmEditando(rtm)}
                         onDelete={() => setConfirmDelete({ tipo: 'rtm', id: rtm.id, nombre: rtm.numeroCertificado })}
+                        isDarkMode={isDarkMode}
                       />
                     </td>
                   </tr>
@@ -290,13 +300,17 @@ export default function DocumentosPage() {
 
       {confirmDelete && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-          <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6">
-            <h2 className="text-xl font-bold text-gray-900 mb-2">Eliminar documento</h2>
-            <p className="text-gray-500 mb-6">
-              Vas a eliminar <span className="font-bold text-gray-800">{confirmDelete.nombre}</span>. Esta accion no se puede deshacer.
+          <div className={`w-full max-w-md rounded-2xl p-6 shadow-2xl ${
+            isDarkMode ? 'bg-slate-900 text-slate-100' : 'bg-white'
+          }`}>
+            <h2 className={`mb-2 text-xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Eliminar documento</h2>
+            <p className={`mb-6 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+              Vas a eliminar <span className={`font-bold ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}>{confirmDelete.nombre}</span>. Esta accion no se puede deshacer.
             </p>
             <div className="flex justify-end gap-3">
-              <button type="button" onClick={() => setConfirmDelete(null)} className="px-4 py-2 text-gray-600 font-medium hover:bg-gray-100 rounded-lg">
+              <button type="button" onClick={() => setConfirmDelete(null)} className={`rounded-lg px-4 py-2 font-medium ${
+                isDarkMode ? 'text-slate-300 hover:bg-slate-800' : 'text-gray-600 hover:bg-gray-100'
+              }`}>
                 Cancelar
               </button>
               <button
@@ -329,24 +343,33 @@ function DocumentTableShell({
   onSearchChange,
   placeholder,
   children,
+  isDarkMode,
 }) {
   return (
-    <div data-onboarding={onboardingId} className="bg-white rounded-3xl shadow-sm border border-gray-100 overflow-hidden mb-8">
-      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 px-6 py-5 border-b border-gray-100">
+    <div data-onboarding={onboardingId} className={`mb-8 overflow-hidden rounded-3xl border shadow-sm ${
+      isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+    }`}>
+      <div className={`flex flex-col justify-between gap-4 border-b px-6 py-5 lg:flex-row lg:items-center ${
+        isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-gray-100'
+      }`}>
         <div className="flex items-center gap-3">
-          <Icon className="w-6 h-6 text-syntix-navy" />
-          <h2 className="text-2xl font-bold text-syntix-navy">
+          <Icon className={`w-6 h-6 ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`} />
+          <h2 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>
             {title} ({count}/{total})
           </h2>
         </div>
         <div className="relative w-full lg:w-96">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <Search className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`} />
           <input
             type="text"
             value={searchTerm}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder={placeholder}
-            className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-syntix-green focus:border-syntix-green outline-none"
+            className={`w-full rounded-lg border py-2 pl-9 pr-4 text-sm outline-none focus:border-syntix-green focus:ring-2 focus:ring-syntix-green ${
+              isDarkMode
+                ? 'border-slate-700 bg-slate-900 text-slate-100 placeholder:text-slate-500'
+                : 'border-gray-300 bg-white text-gray-900'
+            }`}
           />
         </div>
       </div>
@@ -355,23 +378,27 @@ function DocumentTableShell({
   );
 }
 
-function EmptyRows({ colSpan, hasData }) {
+function EmptyRows({ colSpan, hasData, isDarkMode }) {
   return (
     <tr>
-      <td colSpan={colSpan} className="px-6 py-8 text-center text-gray-500">
+      <td colSpan={colSpan} className={`px-6 py-8 text-center ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
         {hasData ? 'No se encontraron registros con ese criterio.' : 'No hay registros para mostrar.'}
       </td>
     </tr>
   );
 }
 
-function RowActions({ onEdit, onDelete }) {
+function RowActions({ onEdit, onDelete, isDarkMode }) {
   return (
     <div className="flex gap-2">
       <button
         type="button"
         onClick={onEdit}
-        className="p-2 rounded-lg text-gray-400 hover:text-syntix-navy hover:bg-gray-100 transition-colors"
+        className={`rounded-lg p-2 transition-colors ${
+          isDarkMode
+            ? 'text-slate-500 hover:bg-slate-800 hover:text-slate-100'
+            : 'text-gray-400 hover:bg-gray-100 hover:text-syntix-navy'
+        }`}
         title="Editar"
       >
         <Pencil className="w-4 h-4" />
@@ -379,7 +406,11 @@ function RowActions({ onEdit, onDelete }) {
       <button
         type="button"
         onClick={onDelete}
-        className="p-2 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+        className={`rounded-lg p-2 transition-colors ${
+          isDarkMode
+            ? 'text-slate-500 hover:bg-red-500/10 hover:text-red-300'
+            : 'text-gray-400 hover:bg-red-50 hover:text-red-500'
+        }`}
         title="Eliminar"
       >
         <Trash2 className="w-4 h-4" />

--- a/apps/web/src/pages/ReportesPage.jsx
+++ b/apps/web/src/pages/ReportesPage.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { AlertTriangle, Car, Download, FileText, ShieldCheck, Users } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import { useVehicles } from '@/hooks/useVehicles.js';
 import { useConductors } from '@/hooks/useConductors.js';
 import { useDocuments } from '@/hooks/useDocuments.js';
@@ -20,6 +21,7 @@ const quoteCsv = (field) => `"${String(field ?? '').replaceAll('"', '""')}"`;
 
 // ReportesPage traduce el estado real de la flota a metricas y exportables simples.
 export default function ReportesPage() {
+  const { isDarkMode } = useTheme();
   const { vehiculos } = useVehicles();
   const { conductores } = useConductors();
   const { soats } = useDocuments();
@@ -138,28 +140,34 @@ export default function ReportesPage() {
 
       <div data-onboarding="reports-header" className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-syntix-navy">Reportes y Analitica</h1>
-          <p className="text-gray-500 text-sm mt-1">Metricas reales de cumplimiento de la flota</p>
+          <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Reportes y Analitica</h1>
+          <p className={`mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Metricas reales de cumplimiento de la flota</p>
         </div>
         <button
           data-onboarding="reports-export"
           onClick={handleExportCSV}
-          className="bg-white border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors flex items-center gap-2 shadow-sm"
+          className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium shadow-sm transition-colors ${
+            isDarkMode
+              ? 'border-slate-700 bg-slate-900 text-slate-200 hover:bg-slate-800'
+              : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+          }`}
         >
           <Download className="w-4 h-4" /> Descargar CSV
         </button>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-4">
-        <MetricCard icon={Car} label="Vehiculos" value={vehiculos.length} hint="Registrados" />
-        <MetricCard icon={Users} label="Conductores" value={conductores.length} hint="Registrados" />
-        <MetricCard icon={ShieldCheck} label="SOAT" value={soats.length} hint="Documentos" />
-        <MetricCard icon={FileText} label="RTM" value={rtms.length} hint="Revisiones" />
-        <MetricCard icon={AlertTriangle} label="Alertas" value={alerts.length} hint="Activas" />
+        <MetricCard icon={Car} label="Vehiculos" value={vehiculos.length} hint="Registrados" isDarkMode={isDarkMode} />
+        <MetricCard icon={Users} label="Conductores" value={conductores.length} hint="Registrados" isDarkMode={isDarkMode} />
+        <MetricCard icon={ShieldCheck} label="SOAT" value={soats.length} hint="Documentos" isDarkMode={isDarkMode} />
+        <MetricCard icon={FileText} label="RTM" value={rtms.length} hint="Revisiones" isDarkMode={isDarkMode} />
+        <MetricCard icon={AlertTriangle} label="Alertas" value={alerts.length} hint="Activas" isDarkMode={isDarkMode} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div data-onboarding="reports-compliance-card" className="bg-syntix-navy rounded-2xl p-8 text-white relative overflow-hidden shadow-lg">
+        <div data-onboarding="reports-compliance-card" className={`relative overflow-hidden rounded-2xl p-8 text-white shadow-lg ${
+          isDarkMode ? 'bg-slate-900' : 'bg-syntix-navy'
+        }`}>
           <div className="absolute top-0 right-0 w-64 h-64 bg-syntix-green rounded-full opacity-20 blur-3xl -mr-20 -mt-20" />
           <div className="relative z-10">
             <h3 className="text-lg font-medium text-gray-300 mb-2">Cumplimiento Total</h3>
@@ -170,12 +178,14 @@ export default function ReportesPage() {
           </div>
         </div>
 
-        <div data-onboarding="reports-distribution-card" className="bg-white rounded-2xl p-8 border border-gray-100 shadow-sm flex flex-col justify-center">
-          <h3 className="text-lg font-bold text-gray-900 mb-6">Distribucion Documental</h3>
+        <div data-onboarding="reports-distribution-card" className={`flex flex-col justify-center rounded-2xl border p-8 shadow-sm ${
+          isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+        }`}>
+          <h3 className={`mb-6 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Distribucion Documental</h3>
           <div className="space-y-4">
-            <StatusBar label="Al Dia (Verde)" value={stateStats.verde} total={stateStats.total} colorClass="bg-syntix-green" textClass="text-syntix-green" />
-            <StatusBar label="Por Vencer (Amarillo)" value={stateStats.amarillo} total={stateStats.total} colorClass="bg-yellow-500" textClass="text-yellow-500" />
-            <StatusBar label="Critico (Rojo)" value={stateStats.rojo} total={stateStats.total} colorClass="bg-syntix-red" textClass="text-syntix-red" />
+            <StatusBar label="Al Dia (Verde)" value={stateStats.verde} total={stateStats.total} colorClass="bg-syntix-green" textClass="text-syntix-green" isDarkMode={isDarkMode} />
+            <StatusBar label="Por Vencer (Amarillo)" value={stateStats.amarillo} total={stateStats.total} colorClass="bg-yellow-500" textClass="text-yellow-500" isDarkMode={isDarkMode} />
+            <StatusBar label="Critico (Rojo)" value={stateStats.rojo} total={stateStats.total} colorClass="bg-syntix-red" textClass="text-syntix-red" isDarkMode={isDarkMode} />
           </div>
         </div>
       </div>
@@ -185,36 +195,42 @@ export default function ReportesPage() {
           title={`Alertas de vehiculos (${vehicleAlerts.length})`}
           emptyMessage="No hay alertas de vehiculos para reportar."
           alerts={vehicleAlerts}
+          isDarkMode={isDarkMode}
         />
         <ReportSection
           title={`Alertas de conductores (${conductorAlerts.length})`}
           emptyMessage="No hay alertas de conductores para reportar."
           alerts={conductorAlerts}
+          isDarkMode={isDarkMode}
         />
       </div>
 
-      <div className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm">
-        <h3 className="text-lg font-bold text-gray-900 mb-4">Resumen Documental</h3>
+      <div className={`rounded-2xl border p-6 shadow-sm ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
+        <h3 className={`mb-4 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Resumen Documental</h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <DocumentSummary title="SOAT" stats={documentStats.soat} alerts={alertStats.soat} />
-          <DocumentSummary title="RTM" stats={documentStats.rtm} alerts={alertStats.rtm} />
-          <DocumentSummary title="Licencias" total={conductores.length} alerts={alertStats.licencias} />
+          <DocumentSummary title="SOAT" stats={documentStats.soat} alerts={alertStats.soat} isDarkMode={isDarkMode} />
+          <DocumentSummary title="RTM" stats={documentStats.rtm} alerts={alertStats.rtm} isDarkMode={isDarkMode} />
+          <DocumentSummary title="Licencias" total={conductores.length} alerts={alertStats.licencias} isDarkMode={isDarkMode} />
         </div>
       </div>
     </div>
   );
 }
 
-function MetricCard({ icon: Icon, label, value, hint }) {
+function MetricCard({ icon: Icon, label, value, hint, isDarkMode }) {
   return (
-    <div className="bg-white rounded-xl p-4 border border-gray-100 shadow-sm">
+    <div className={`rounded-xl border p-4 shadow-sm ${
+      isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+    }`}>
       <div className="flex items-center justify-between gap-3">
         <div>
-          <p className="text-sm text-gray-500">{label}</p>
-          <p className="text-3xl font-black text-syntix-navy mt-1">{value}</p>
-          <p className="text-xs text-gray-400 mt-1">{hint}</p>
+          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{label}</p>
+          <p className={`mt-1 text-3xl font-black ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>{value}</p>
+          <p className={`mt-1 text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>{hint}</p>
         </div>
-        <div className="p-3 rounded-lg bg-gray-50 text-syntix-navy">
+        <div className={`rounded-lg p-3 ${isDarkMode ? 'bg-slate-800 text-slate-100' : 'bg-gray-50 text-syntix-navy'}`}>
           <Icon className="w-5 h-5" />
         </div>
       </div>
@@ -222,27 +238,31 @@ function MetricCard({ icon: Icon, label, value, hint }) {
   );
 }
 
-function StatusBar({ label, value, total, colorClass, textClass }) {
+function StatusBar({ label, value, total, colorClass, textClass, isDarkMode }) {
   return (
     <div>
       <div className="flex justify-between text-sm font-bold mb-1">
         <span className={textClass}>{label}</span>
-        <span>{value}</span>
+        <span className={isDarkMode ? 'text-slate-200' : 'text-gray-700'}>{value}</span>
       </div>
-      <div className="w-full bg-gray-100 rounded-full h-2.5">
+      <div className={`h-2.5 w-full rounded-full ${isDarkMode ? 'bg-slate-800' : 'bg-gray-100'}`}>
         <div className={`${colorClass} h-2.5 rounded-full`} style={{ width: progressWidth(value, total) }} />
       </div>
     </div>
   );
 }
 
-function ReportSection({ title, alerts, emptyMessage }) {
+function ReportSection({ title, alerts, emptyMessage, isDarkMode }) {
   return (
-    <div className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm">
-      <h3 className="text-lg font-bold text-gray-900 mb-4">{title}</h3>
+    <div className={`rounded-2xl border p-6 shadow-sm ${
+      isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+    }`}>
+      <h3 className={`mb-4 text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{title}</h3>
 
       {alerts.length === 0 ? (
-        <div className="text-sm text-gray-500 bg-gray-50 rounded-lg border border-dashed border-gray-200 p-4">
+        <div className={`rounded-lg border border-dashed p-4 text-sm ${
+          isDarkMode ? 'border-slate-700 bg-slate-950/60 text-slate-400' : 'border-gray-200 bg-gray-50 text-gray-500'
+        }`}>
           {emptyMessage}
         </div>
       ) : (
@@ -251,11 +271,13 @@ function ReportSection({ title, alerts, emptyMessage }) {
             const expiration = getExpirationAlertText(alert.diasRestantes, alert.fechaVencimiento);
 
             return (
-              <div key={alert.id} className="border border-gray-100 rounded-xl p-4 bg-gray-50">
+              <div key={alert.id} className={`rounded-xl border p-4 ${
+                isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-gray-100 bg-gray-50'
+              }`}>
                 <div className="flex justify-between gap-3">
                   <div>
-                    <p className="font-bold text-gray-900">{alert.mensaje}</p>
-                    <p className="text-sm text-gray-600 mt-1">
+                    <p className={`font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{alert.mensaje}</p>
+                    <p className={`mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
                       {alert.tipo}: {alert.entidad}
                     </p>
                   </div>
@@ -263,7 +285,7 @@ function ReportSection({ title, alerts, emptyMessage }) {
                     {statusLabels[alert.prioridad] || alert.prioridad}
                   </span>
                 </div>
-                <p className="text-xs text-gray-500 font-semibold mt-2">{expiration.fullText}</p>
+                <p className={`mt-2 text-xs font-semibold ${isDarkMode ? 'text-slate-500' : 'text-gray-500'}`}>{expiration.fullText}</p>
               </div>
             );
           })}
@@ -273,22 +295,24 @@ function ReportSection({ title, alerts, emptyMessage }) {
   );
 }
 
-function DocumentSummary({ title, total, alerts, stats = null }) {
+function DocumentSummary({ title, total, alerts, stats = null, isDarkMode }) {
   const totalValue = stats?.total ?? total;
 
   return (
-    <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
-      <p className="text-sm text-gray-500">{title}</p>
-      <p className="text-2xl font-black text-syntix-navy mt-1">{totalValue}</p>
+    <div className={`rounded-xl border p-4 ${
+      isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-gray-100 bg-gray-50'
+    }`}>
+      <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{title}</p>
+      <p className={`mt-1 text-2xl font-black ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>{totalValue}</p>
       {stats && (
-        <div className="grid grid-cols-2 gap-2 mt-3 text-xs text-gray-600">
+        <div className={`mt-3 grid grid-cols-2 gap-2 text-xs ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
           <span>Vigentes: <strong>{stats.vigente}</strong></span>
           <span>Proximos: <strong>{stats.proximo}</strong></span>
           <span>Vencidos: <strong>{stats.vencido}</strong></span>
           <span>Sin registro: <strong>{stats.faltantes}</strong></span>
         </div>
       )}
-      <p className="text-xs text-gray-500 mt-1">
+      <p className={`mt-1 text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-500'}`}>
         {alerts} alertas activas
       </p>
     </div>

--- a/apps/web/src/pages/UserProfilePage.jsx
+++ b/apps/web/src/pages/UserProfilePage.jsx
@@ -1,0 +1,222 @@
+import React, { useMemo } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import { Building2, Car, Mail, Phone, ShieldCheck, TriangleAlert, Users, UserCircle2 } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext.jsx';
+import { useVehicles } from '@/hooks/useVehicles.js';
+import { useConductors } from '@/hooks/useConductors.js';
+import { useAlerts } from '@/hooks/useAlerts.js';
+import ThemeToggle from '@/components/ThemeToggle.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
+
+// UserProfilePage concentra la entrada inicial al perfil sin mezclarla con la
+// configuración global del sistema. La idea es mostrar identidad + resumen
+// operativo y dejar una base clara para preferencias y seguridad en sprints siguientes.
+export default function UserProfilePage() {
+  const { user } = useAuth();
+  const { vehiculos } = useVehicles();
+  const { conductores } = useConductors();
+  const { alerts } = useAlerts();
+  const { isDarkMode } = useTheme();
+
+  const stats = useMemo(
+    () => [
+      { label: 'Vehiculos registrados', value: vehiculos.length, icon: Car, tone: 'text-syntix-navy' },
+      { label: 'Conductores activos', value: conductores.length, icon: Users, tone: 'text-syntix-green' },
+      { label: 'Alertas pendientes', value: alerts.length, icon: TriangleAlert, tone: 'text-syntix-red' },
+    ],
+    [vehiculos.length, conductores.length, alerts.length]
+  );
+
+  const recentVehicles = useMemo(() => vehiculos.slice(-3).reverse(), [vehiculos]);
+  const userInitial = useMemo(
+    () => String(user?.empresa || user?.email || 'U').charAt(0).toUpperCase(),
+    [user?.empresa, user?.email]
+  );
+
+  return (
+    <div className="space-y-6">
+      <Helmet>
+        <title>Perfil | SYNTIX Drive Control</title>
+      </Helmet>
+
+      <section className={`overflow-hidden rounded-3xl border shadow-sm ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
+        <div className={`flex flex-col gap-6 px-6 py-8 text-white lg:flex-row lg:items-center lg:justify-between ${
+          isDarkMode ? 'bg-gradient-to-r from-slate-950 via-slate-900 to-slate-800' : 'bg-gradient-to-r from-syntix-navy to-slate-800'
+        }`}>
+          <div className="flex items-center gap-4">
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-white/10 text-3xl font-bold">
+              {userInitial}
+            </div>
+
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Perfil de usuario</p>
+              <h1 className="mt-2 text-3xl font-bold">{user?.empresa || 'Usuario autenticado'}</h1>
+              <p className="mt-2 max-w-2xl text-sm text-white/80">
+                Aqui puedes revisar tu informacion principal y un resumen rapido de la flota asociada a tu cuenta.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <ThemeToggle compact label="Modo oscuro" />
+            <Link to="/vehiculos" className="rounded-xl bg-white px-4 py-2 text-sm font-semibold text-syntix-navy transition hover:bg-gray-100">
+              Ver vehiculos
+            </Link>
+            <Link to="/configuracion" className="rounded-xl border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10">
+              Ir a configuracion
+            </Link>
+          </div>
+        </div>
+
+        <div className="grid gap-4 px-6 py-6 lg:grid-cols-[1.1fr,0.9fr]">
+            <div className="space-y-4">
+              <ProfileField
+                icon={Building2}
+                label="Empresa"
+                value={user?.empresa || 'Sin informacion registrada'}
+                isDarkMode={isDarkMode}
+              />
+              <ProfileField
+                icon={Mail}
+                label="Correo"
+                value={user?.email || 'Sin correo disponible'}
+                isDarkMode={isDarkMode}
+              />
+              <ProfileField
+                icon={Phone}
+                label="Telefono"
+                value={user?.telefono || 'Sin telefono disponible'}
+                isDarkMode={isDarkMode}
+              />
+              <ProfileField
+                icon={ShieldCheck}
+                label="Rol"
+                value={user?.role || 'Sin rol disponible'}
+                isDarkMode={isDarkMode}
+              />
+            </div>
+
+          <div className={`rounded-2xl border border-dashed p-5 ${
+            isDarkMode ? 'border-slate-700 bg-slate-950/60' : 'border-gray-200 bg-gray-50'
+          }`}>
+            <div className="flex items-center gap-3">
+              <UserCircle2 className="h-5 w-5 text-syntix-navy" />
+              <h2 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Estado del modulo</h2>
+            </div>
+            <p className={`mt-3 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+              Esta es la primera version del perfil. Ya puedes guardar la preferencia de modo oscuro y en Sprint 13
+              se pueden extender acciones sensibles como cambio de contrasena y cambio de correo con validaciones adicionales.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {stats.map((stat) => (
+          <article key={stat.label} className={`rounded-2xl border p-5 shadow-sm ${
+            isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+          }`}>
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{stat.label}</p>
+                <p className={`mt-2 text-3xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{stat.value}</p>
+              </div>
+              <stat.icon className={`h-8 w-8 ${stat.tone}`} />
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[1.1fr,0.9fr]">
+        <article className={`rounded-2xl border p-5 shadow-sm ${
+          isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+        }`}>
+          <div className="flex items-center justify-between gap-3">
+            <h2 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Vehiculos recientes</h2>
+            <Link to="/vehiculos" className="text-sm font-semibold text-syntix-navy hover:underline">
+              Ver todos
+            </Link>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {recentVehicles.length > 0 ? (
+              recentVehicles.map((vehicle) => (
+                <div
+                  key={vehicle.id}
+                  className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 ${
+                    isDarkMode ? 'border-slate-800 bg-slate-950/70' : 'border-gray-100 bg-gray-50'
+                  }`}
+                >
+                  <div>
+                    <p className={`font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{vehicle.placa}</p>
+                    <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {vehicle.marca} {vehicle.modelo} - {vehicle.tipo}
+                    </p>
+                  </div>
+                  <span className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    isDarkMode ? 'bg-slate-800 text-slate-300' : 'bg-white text-gray-600'
+                  }`}>
+                    {vehicle.estadoGeneral || 'sin estado'}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <EmptyState text="Todavia no hay vehiculos registrados para mostrar en tu perfil." isDarkMode={isDarkMode} />
+            )}
+          </div>
+        </article>
+
+        <article className={`rounded-2xl border p-5 shadow-sm ${
+          isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+        }`}>
+          <h2 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Siguientes mejoras</h2>
+          <div className="mt-4 space-y-3">
+            <FutureItem title="Preferencias avanzadas" text="Refinar colores, densidad visual y accesibilidad segun el perfil del usuario." isDarkMode={isDarkMode} />
+            <FutureItem title="Cambio de contrasena" text="Agregar una accion segura para actualizar credenciales." isDarkMode={isDarkMode} />
+            <FutureItem title="Cambio de correo" text="Soportar validacion y confirmacion del nuevo correo." isDarkMode={isDarkMode} />
+          </div>
+        </article>
+      </section>
+    </div>
+  );
+}
+
+function ProfileField({ icon: Icon, label, value, isDarkMode }) {
+  return (
+    <div className={`flex items-start gap-3 rounded-2xl border px-4 py-3 ${
+      isDarkMode ? 'border-slate-800 bg-slate-950/70' : 'border-gray-100 bg-gray-50'
+    }`}>
+      <div className={`rounded-xl p-2 text-syntix-navy shadow-sm ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
+        <Icon className="h-4 w-4" />
+      </div>
+      <div>
+        <p className={`text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{label}</p>
+        <p className={`mt-1 text-sm font-medium ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ text, isDarkMode }) {
+  return (
+    <div className={`rounded-2xl border border-dashed px-4 py-6 text-sm ${
+      isDarkMode ? 'border-slate-700 bg-slate-950/60 text-slate-400' : 'border-gray-200 bg-gray-50 text-gray-500'
+    }`}>
+      {text}
+    </div>
+  );
+}
+
+function FutureItem({ title, text, isDarkMode }) {
+  return (
+    <div className={`rounded-2xl border px-4 py-3 ${
+      isDarkMode ? 'border-slate-800 bg-slate-950/70' : 'border-gray-100 bg-gray-50'
+    }`}>
+      <p className={`font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{title}</p>
+      <p className={`mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>{text}</p>
+    </div>
+  );
+}

--- a/apps/web/src/pages/UserProfilePage.jsx
+++ b/apps/web/src/pages/UserProfilePage.jsx
@@ -21,11 +21,11 @@ export default function UserProfilePage() {
 
   const stats = useMemo(
     () => [
-      { label: 'Vehiculos registrados', value: vehiculos.length, icon: Car, tone: 'text-syntix-navy' },
+      { label: 'Vehiculos registrados', value: vehiculos.length, icon: Car, tone: isDarkMode ? 'text-slate-100' : 'text-syntix-navy' },
       { label: 'Conductores activos', value: conductores.length, icon: Users, tone: 'text-syntix-green' },
       { label: 'Alertas pendientes', value: alerts.length, icon: TriangleAlert, tone: 'text-syntix-red' },
     ],
-    [vehiculos.length, conductores.length, alerts.length]
+    [vehiculos.length, conductores.length, alerts.length, isDarkMode]
   );
 
   const recentVehicles = useMemo(() => vehiculos.slice(-3).reverse(), [vehiculos]);
@@ -103,7 +103,7 @@ export default function UserProfilePage() {
             isDarkMode ? 'border-slate-700 bg-slate-950/60' : 'border-gray-200 bg-gray-50'
           }`}>
             <div className="flex items-center gap-3">
-              <UserCircle2 className="h-5 w-5 text-syntix-navy" />
+              <UserCircle2 className={`h-5 w-5 ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`} />
               <h2 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Estado del modulo</h2>
             </div>
             <p className={`mt-3 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
@@ -136,7 +136,7 @@ export default function UserProfilePage() {
         }`}>
           <div className="flex items-center justify-between gap-3">
             <h2 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>Vehiculos recientes</h2>
-            <Link to="/vehiculos" className="text-sm font-semibold text-syntix-navy hover:underline">
+            <Link to="/vehiculos" className={`text-sm font-semibold hover:underline ${isDarkMode ? 'text-slate-200' : 'text-syntix-navy'}`}>
               Ver todos
             </Link>
           </div>
@@ -189,7 +189,7 @@ function ProfileField({ icon: Icon, label, value, isDarkMode }) {
     <div className={`flex items-start gap-3 rounded-2xl border px-4 py-3 ${
       isDarkMode ? 'border-slate-800 bg-slate-950/70' : 'border-gray-100 bg-gray-50'
     }`}>
-      <div className={`rounded-xl p-2 text-syntix-navy shadow-sm ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
+      <div className={`rounded-xl p-2 shadow-sm ${isDarkMode ? 'bg-slate-800 text-slate-200' : 'bg-white text-syntix-navy'}`}>
         <Icon className="h-4 w-4" />
       </div>
       <div>

--- a/apps/web/src/pages/ValidacionRUNTPage.jsx
+++ b/apps/web/src/pages/ValidacionRUNTPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Search, Database, XCircle } from 'lucide-react';
 import ValidacionResultadoCard from '@/components/ValidacionResultadoCard.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import { useRUNTSimulator } from '@/hooks/useRUNTSimulator.js';
 import { useValidationHistory } from '@/hooks/useValidationHistory.js';
 import { useVehicles } from '@/hooks/useVehicles.js';
@@ -9,6 +10,7 @@ import { useConductors } from '@/hooks/useConductors.js';
 
 // ValidacionRUNTPage orquesta la búsqueda externa simulada y la guarda como evidencia interna.
 export default function ValidacionRUNTPage() {
+  const { isDarkMode } = useTheme();
   const [searchInput, setSearchInput] = useState('');
   const [searchType, setSearchType] = useState('placa'); // 'placa' o 'vin'
   const [result, setResult] = useState(null);
@@ -75,19 +77,23 @@ export default function ValidacionRUNTPage() {
       </Helmet>
 
       <div data-onboarding="runt-header" className="text-center mb-8">
-        <div className="w-16 h-16 bg-syntix-navy/5 rounded-2xl flex items-center justify-center mx-auto mb-4">
-          <Database className="w-8 h-8 text-syntix-navy" />
+        <div className={`mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl ${
+          isDarkMode ? 'bg-slate-900 text-slate-100' : 'bg-syntix-navy/5 text-syntix-navy'
+        }`}>
+          <Database className="w-8 h-8" />
         </div>
-        <h1 className="text-3xl font-bold text-syntix-navy">Validación RUNT</h1>
-        <p className="text-gray-500 mt-2">Consulta el Registro Único Nacional de Tránsito</p>
+        <h1 className={`text-3xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Validación RUNT</h1>
+        <p className={`mt-2 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Consulta el Registro Único Nacional de Tránsito</p>
       </div>
 
       {/* Formulario de Búsqueda */}
-      <div data-onboarding="runt-search" className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 space-y-4">
+      <div data-onboarding="runt-search" className={`space-y-4 rounded-2xl border p-8 shadow-lg ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
         <form onSubmit={handleSearch} className="space-y-4">
           {/* Selector de Tipo de Búsqueda */}
           <div data-onboarding="runt-search-type" className="flex gap-4">
-            <label className="flex items-center gap-2 cursor-pointer">
+            <label className={`flex cursor-pointer items-center gap-2 ${isDarkMode ? 'text-slate-200' : ''}`}>
               <input 
                 type="radio" 
                 value="placa" 
@@ -95,9 +101,9 @@ export default function ValidacionRUNTPage() {
                 onChange={(e) => setSearchType(e.target.value)}
                 className="w-4 h-4"
               />
-              <span className="font-medium text-gray-700">Buscar por Placa</span>
+              <span className={`font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}>Buscar por Placa</span>
             </label>
-            <label className="flex items-center gap-2 cursor-pointer">
+            <label className={`flex cursor-pointer items-center gap-2 ${isDarkMode ? 'text-slate-200' : ''}`}>
               <input 
                 type="radio" 
                 value="vin" 
@@ -105,20 +111,24 @@ export default function ValidacionRUNTPage() {
                 onChange={(e) => setSearchType(e.target.value)}
                 className="w-4 h-4"
               />
-              <span className="font-medium text-gray-700">Buscar por VIN</span>
+              <span className={`font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}>Buscar por VIN</span>
             </label>
           </div>
 
           {/* Input de Búsqueda */}
           <div className="flex flex-col sm:flex-row gap-4">
             <div data-onboarding="runt-search-input" className="flex-1 relative">
-              <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Search className={`absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`} />
               <input 
                 type="text" 
                 placeholder={searchType === 'placa' ? 'Ej. ABC-123' : 'Ej. WVWZZZ3CZ9E123456'}
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value.toUpperCase())}
-                className="w-full pl-12 pr-4 py-4 border-2 border-gray-200 rounded-xl text-lg font-bold uppercase tracking-wider focus:ring-0 focus:border-syntix-green text-gray-900 transition-colors"
+                className={`w-full rounded-xl border-2 py-4 pl-12 pr-4 text-lg font-bold uppercase tracking-wider transition-colors focus:border-syntix-green focus:ring-0 ${
+                  isDarkMode
+                    ? 'border-slate-700 bg-slate-950 text-slate-100 placeholder:text-slate-500'
+                    : 'border-gray-200 text-gray-900'
+                }`}
                 maxLength={searchType === 'placa' ? 7 : 17}
               />
             </div>
@@ -134,8 +144,10 @@ export default function ValidacionRUNTPage() {
 
           {/* Búsquedas Recientes */}
           {recentSearches.length > 0 && (
-            <div data-onboarding="runt-recent-searches" className="p-3 bg-gray-50 rounded-lg">
-              <p className="text-xs font-bold text-gray-600 mb-2">Búsquedas recientes:</p>
+            <div data-onboarding="runt-recent-searches" className={`rounded-lg p-3 ${
+              isDarkMode ? 'bg-slate-950/70' : 'bg-gray-50'
+            }`}>
+              <p className={`mb-2 text-xs font-bold ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>Búsquedas recientes:</p>
               <div className="flex flex-wrap gap-2">
                 {recentSearches.map(placa => (
                   <button
@@ -145,7 +157,11 @@ export default function ValidacionRUNTPage() {
                       setSearchInput(placa);
                       setSearchType('placa');
                     }}
-                    className="px-3 py-1 bg-white border border-gray-300 rounded-lg text-sm hover:bg-gray-100 transition-colors"
+                    className={`rounded-lg border px-3 py-1 text-sm transition-colors ${
+                      isDarkMode
+                        ? 'border-slate-700 bg-slate-900 text-slate-200 hover:bg-slate-800'
+                        : 'border-gray-300 bg-white hover:bg-gray-100'
+                    }`}
                   >
                     {placa}
                   </button>
@@ -160,12 +176,14 @@ export default function ValidacionRUNTPage() {
       {result && (
         <div className="animate-in fade-in slide-in-from-bottom-4 duration-300">
           {result.error && (
-            <div className="bg-red-50 border-2 border-red-200 rounded-2xl p-8 text-center">
+            <div className={`rounded-2xl border-2 p-8 text-center ${
+              isDarkMode ? 'border-red-900 bg-red-950/40' : 'border-red-200 bg-red-50'
+            }`}>
               <div className="flex justify-center mb-4">
                 <XCircle className="w-12 h-12 text-syntix-red" />
               </div>
               <h3 className="text-xl font-bold text-syntix-red mb-2">Búsqueda sin resultados</h3>
-              <p className="text-red-700">{result.error}</p>
+              <p className={isDarkMode ? 'text-red-300' : 'text-red-700'}>{result.error}</p>
             </div>
           )}
 
@@ -176,17 +194,20 @@ export default function ValidacionRUNTPage() {
               conductorAsignado={vehiculos.find(v => v.placa === result.data.placa)?.conductor}
               onGuardar={handleSaveValidation}
               loading={loading}
+              isDarkMode={isDarkMode}
             />
           )}
         </div>
       )}
 
       {/* Link a Historial */}
-      <div data-onboarding="runt-history-link" className="text-center p-6 bg-syntix-navy/5 rounded-xl">
-        <p className="text-gray-600 mb-2">¿Quieres ver todas tus validaciones?</p>
+      <div data-onboarding="runt-history-link" className={`rounded-xl p-6 text-center ${
+        isDarkMode ? 'bg-slate-900' : 'bg-syntix-navy/5'
+      }`}>
+        <p className={`mb-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>¿Quieres ver todas tus validaciones?</p>
         <a 
           href="/historial-validaciones"
-          className="text-syntix-navy font-bold hover:underline"
+          className={`font-bold hover:underline ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}
         >
           Ver Historial Completo →
         </a>

--- a/apps/web/src/pages/VehiculosPage.jsx
+++ b/apps/web/src/pages/VehiculosPage.jsx
@@ -4,12 +4,14 @@ import { Search, Plus, Trash2, Car } from 'lucide-react';
 import StatusBadge from '@/components/StatusBadge.jsx';
 import AddVehicleModal from '@/components/AddVehicleModal.jsx';
 import { useOnboarding } from '@/contexts/OnboardingContext.jsx';
+import { useTheme } from '@/contexts/ThemeContext.jsx';
 import { useVehicles } from '@/hooks/useVehicles.js';
 
 // Vista principal de flota: combina búsqueda, filtros y edición sobre los vehículos del usuario.
 export default function VehiculosPage() {
   const { vehiculos, deleteVehicle } = useVehicles();
   const { currentStep, isTourActive } = useOnboarding();
+  const { isDarkMode } = useTheme();
   const tutorialOpenedModalRef = useRef(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [filterState, setFilterState] = useState('todos');
@@ -81,8 +83,8 @@ export default function VehiculosPage() {
         className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4"
       >
         <div>
-          <h1 className="text-2xl font-bold text-syntix-navy">Gestion de Vehiculos</h1>
-          <p className="text-sm text-gray-500 mt-1">
+          <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-syntix-navy'}`}>Gestion de Vehiculos</h1>
+          <p className={`mt-1 text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
             Consulta, registra y valida los vehiculos asociados al usuario dentro del sistema.
           </p>
         </div>
@@ -97,16 +99,24 @@ export default function VehiculosPage() {
         </button>
       </div>
 
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="p-4 border-b border-gray-100 flex flex-col sm:flex-row gap-4 justify-between bg-gray-50/50">
+      <div className={`overflow-hidden rounded-2xl border shadow-sm ${
+        isDarkMode ? 'border-slate-800 bg-slate-900' : 'border-gray-100 bg-white'
+      }`}>
+        <div className={`flex flex-col justify-between gap-4 border-b p-4 sm:flex-row ${
+          isDarkMode ? 'border-slate-800 bg-slate-950/60' : 'border-gray-100 bg-gray-50/50'
+        }`}>
           <div data-onboarding="vehicles-search" className="relative w-full sm:w-96">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <Search className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`} />
             <input
               type="text"
               placeholder="Buscar por placa, marca, modelo o usuario..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-syntix-green focus:border-syntix-green outline-none"
+              className={`w-full rounded-lg border py-2 pl-9 pr-4 text-sm outline-none focus:border-syntix-green focus:ring-2 focus:ring-syntix-green ${
+                isDarkMode
+                  ? 'border-slate-700 bg-slate-900 text-slate-100 placeholder:text-slate-500'
+                  : 'border-gray-300 bg-white text-gray-900'
+              }`}
             />
           </div>
 
@@ -114,7 +124,11 @@ export default function VehiculosPage() {
             data-onboarding="vehicles-filter"
             value={filterState}
             onChange={(e) => setFilterState(e.target.value)}
-            className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white focus:ring-2 focus:ring-syntix-green outline-none"
+            className={`rounded-lg border px-4 py-2 text-sm font-medium outline-none focus:ring-2 focus:ring-syntix-green ${
+              isDarkMode
+                ? 'border-slate-700 bg-slate-900 text-slate-200'
+                : 'border-gray-300 bg-white text-gray-700'
+            }`}
           >
             <option value="todos">Todos los estados</option>
             <option value="verde">Al Dia (Verde)</option>
@@ -124,8 +138,10 @@ export default function VehiculosPage() {
         </div>
 
         <div data-onboarding="vehicles-table" className="overflow-x-auto">
-          <table className="w-full text-left text-sm text-gray-600">
-            <thead className="bg-gray-50 text-gray-700 font-semibold border-b border-gray-200">
+          <table className={`w-full text-left text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+            <thead className={`border-b font-semibold ${
+              isDarkMode ? 'border-slate-800 bg-slate-950 text-slate-300' : 'border-gray-200 bg-gray-50 text-gray-700'
+            }`}>
               <tr>
                 <th className="px-6 py-4">Placa</th>
                 <th className="px-6 py-4">Vehiculo</th>
@@ -136,27 +152,27 @@ export default function VehiculosPage() {
                 <th className="px-6 py-4 text-right">Acciones</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className={isDarkMode ? 'divide-y divide-slate-800' : 'divide-y divide-gray-100'}>
               {filteredVehiculos.map((v) => (
-                <tr key={v.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-6 py-4 font-bold text-gray-900">{v.placa}</td>
+                <tr key={v.id} className={`transition-colors ${isDarkMode ? 'hover:bg-slate-800/70' : 'hover:bg-gray-50'}`}>
+                  <td className={`px-6 py-4 font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{v.placa}</td>
                   <td className="px-6 py-4">
-                    <div className="font-medium text-gray-900">
+                    <div className={`font-medium ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
                       {v.marca} {v.modelo}
                     </div>
-                    <div className="text-xs text-gray-500">
+                    <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
                       {v.tipo} - {v.anio}
                     </div>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="font-medium text-gray-900">{v.ownerLabel}</div>
-                    {v.ownerEmail && <div className="text-xs text-gray-500">{v.ownerEmail}</div>}
+                    <div className={`font-medium ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{v.ownerLabel}</div>
+                    {v.ownerEmail && <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{v.ownerEmail}</div>}
                   </td>
                   <td className="px-6 py-4">
                     {v.conductor ? (
-                      <span className="font-medium text-gray-900">{v.conductor.nombre}</span>
+                      <span className={`font-medium ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>{v.conductor.nombre}</span>
                     ) : (
-                      <span className="text-gray-400 italic">Sin asignar</span>
+                      <span className={`italic ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>Sin asignar</span>
                     )}
                   </td>
                   <td className="px-6 py-4">
@@ -166,7 +182,11 @@ export default function VehiculosPage() {
                     <button
                       type="button"
                       onClick={() => openEditModal(v)}
-                      className="inline-flex items-center justify-center px-3 py-1.5 text-xs font-semibold text-syntix-navy bg-syntix-navy/5 hover:bg-syntix-navy/10 rounded-lg transition-colors"
+                      className={`inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                        isDarkMode
+                          ? 'bg-syntix-green/10 text-syntix-green hover:bg-syntix-green/20'
+                          : 'bg-syntix-navy/5 text-syntix-navy hover:bg-syntix-navy/10'
+                      }`}
                       aria-label={`Editar vehiculo ${v.placa}`}
                     >
                       Editar
@@ -176,7 +196,11 @@ export default function VehiculosPage() {
                     <button
                       type="button"
                       onClick={() => deleteVehicle(v.id)}
-                      className="p-2 text-gray-400 hover:text-syntix-red hover:bg-red-50 rounded-lg transition-colors"
+                      className={`rounded-lg p-2 transition-colors ${
+                        isDarkMode
+                          ? 'text-slate-500 hover:bg-red-500/10 hover:text-red-300'
+                          : 'text-gray-400 hover:bg-red-50 hover:text-syntix-red'
+                      }`}
                       aria-label={`Eliminar vehiculo ${v.placa}`}
                     >
                       <Trash2 className="w-4 h-4" />
@@ -187,12 +211,12 @@ export default function VehiculosPage() {
 
               {filteredVehiculos.length === 0 && (
                 <tr>
-                  <td colSpan="7" className="px-6 py-12 text-center text-gray-500">
+                  <td colSpan="7" className={`px-6 py-12 text-center ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
                     <div className="flex flex-col items-center gap-3">
-                      <Car className="w-8 h-8 text-gray-300" />
+                      <Car className={`w-8 h-8 ${isDarkMode ? 'text-slate-600' : 'text-gray-300'}`} />
                       <div>
-                        <p className="font-medium text-gray-700">Aun no hay vehiculos para mostrar.</p>
-                        <p className="text-sm text-gray-500">
+                        <p className={`font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}>Aun no hay vehiculos para mostrar.</p>
+                        <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
                           Agrega un vehiculo para comenzar a gestionar la flota.
                         </p>
                       </div>


### PR DESCRIPTION
# Pull Request: Perfil de usuario y modo oscuro consistente

## Rama origen
`feature-samuelfl680`

## Rama destino
`develop`

## Descripción

Este PR incorpora el primer módulo de perfil de usuario dentro del entorno autenticado y extiende el soporte de modo oscuro a los módulos principales del sistema.

Además de crear la entrada al perfil, la vista inicial del usuario y la persistencia de preferencias visuales, se ajustó la experiencia visual del dashboard para que fondos, textos, bordes, tablas, tarjetas e iconografía mantengan contraste adecuado en modo oscuro.

## Issues relacionadas

Closes #544.
Closes #545.
Closes #547.
Relacionado con #546.

## Resumen de cambios

### Perfil de usuario

- Se agregó la ruta protegida `/perfil`.
- Se añadió el acceso al perfil desde el sidebar y desde el menú del usuario.
- Se implementó una vista inicial de perfil con:
  - información principal del usuario autenticado
  - resumen de flota
  - métricas rápidas
  - vehículos recientes
- Se mantuvo `ConfiguracionPage` como módulo aparte para no mezclar perfil con ajustes globales.

### Dropdown y navegación autenticada

- Se reutilizó el menú de usuario en header público y privado.
- Se ajustaron variantes visuales para evitar regresiones entre header claro y oscuro.
- Se corrigieron enlaces del dropdown hacia perfil y configuración.
- Se movió `Perfil` por encima de `Dashboard` en la navegación lateral.

### Modo oscuro

- Se creó un contexto global de tema con persistencia en `localStorage`.
- Se conectó la clase `dark` al árbol principal de la app.
- Se añadieron overrides globales de tema en estilos base.
- Se dejó el toggle visible solo en:
  - perfil
  - configuración
- Se retiró el toggle del header superior.

### Cobertura visual del modo oscuro

Se ajustó el modo oscuro en los módulos principales:

- Dashboard
- Vehículos
- Conductores
- Documentos
- Alertas
- Validación RUNT
- Reportes
- Perfil
- Configuración

### Ajustes de contraste e iconografía

- Se corrigieron superficies que seguían en blanco dentro del entorno oscuro.
- Se corrigieron textos oscuros sobre fondos oscuros.
- Se aclararon íconos y acentos que conservaban colores demasiado oscuros en dark mode.
- Se mantuvo una paleta compatible con la identidad visual de SYNTIX.

## Pruebas realizadas

- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`
- `npm --prefix apps/web test`

## Checklist

- [x] Existe acceso visible al perfil dentro del entorno autenticado.
- [x] El perfil muestra información principal del usuario y resumen de flota.
- [x] El modo oscuro se guarda entre sesiones.
- [x] El modo oscuro cubre los módulos principales del dashboard.
- [x] El toggle quedó ubicado solo en perfil y configuración.
- [x] Se corrigió el contraste de íconos y elementos visuales en dark mode.
- [x] No se alteró el backend para esta funcionalidad.

## Cierre

Closes #544.
Closes #545.
Closes #547.
