### PR TITLE
fix(sonar): usar clases de digitos concisas en formatos colombianos. …

### DIFF
--- a/apps/web/src/utils/colombiaFormats.js
+++ b/apps/web/src/utils/colombiaFormats.js
@@ -1,7 +1,7 @@
-export const PLATE_REGEX = /^[A-Z]{3}[0-9]{3}$/;
-export const CEDULA_REGEX = /^[0-9]{10}$/;
-export const COLOMBIAN_MOBILE_REGEX = /^3[0-9]{9}$/;
-export const DOCUMENT_CODE_REGEX = /^[A-Z0-9-]{6,30}$/;
+export const PLATE_REGEX = /^[A-Z]{3}\d{3}$/;
+export const CEDULA_REGEX = /^\d{10}$/;
+export const COLOMBIAN_MOBILE_REGEX = /^3\d{9}$/;
+export const DOCUMENT_CODE_REGEX = /^[A-Z\d-]{6,30}$/;
 
 export const normalizePlate = (value) =>
   String(value ?? '')
@@ -57,7 +57,7 @@ export const isDateRangeValid = (startDate, endDate) => {
 export const sanitizePlate = (value) => {
   return String(value ?? '')
     .toUpperCase()
-    .replace(/[^A-Z0-9]/g, '')
+    .replace(/[^A-Z\d]/g, '')
     .slice(0, 6);
 };
 
@@ -81,7 +81,7 @@ export const sanitizePhone = (value) => {
   const digits = String(value ?? '').replace(/\D/g, '');
 
   return digits
-    .replace(/^57(?=3[0-9]{9})/, '')
+    .replace(/^57(?=3\d{9})/, '')
     .slice(0, 10);
 };
 


### PR DESCRIPTION
## Actualización de calidad y SonarCloud

Se corrigió la observación de mantenibilidad reportada por SonarCloud en `apps/web/src/utils/colombiaFormats.js`, reemplazando clases de caracteres numéricas por sintaxis concisa para dígitos.

También se validó nuevamente el proyecto antes de actualizar el PR:

- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`
- `npm --prefix apps/web run test -- --coverage`

Resultado local:

- Build exitoso.
- 8 archivos de prueba ejecutados correctamente.
- 113 tests pasaron.
- Coverage global:
  - Statements: 98%
  - Branches: 92.13%
  - Functions: 100%
  - Lines: 98.64%
- `colombiaFormats.js`: 100% en statements, branches, functions y lines.

Con esto queda corregida la observación de maintainability y se mantiene la cobertura reforzada para SonarCloud.
